### PR TITLE
FEAT-4076 -  UI change share type throws a add event we should make it a modify event

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -77,13 +77,6 @@ const App = ({
   let timeoutReturn;
 
   const [isInDesktopOnlyMode] = useSelector(state => [selectors.isInDesktopOnlyMode(state)]);
-  const [notesShareTypesMap, setNotesShareTypesMap] = useState([]);
-  const setNotesShareType = useCallback(
-    (sharetype, index) => {
-      setNotesShareTypesMap(map => ({ ...map, [index]: sharetype }));
-    },
-    [setNotesShareTypesMap],
-  );
   useEffect(() => {
     fireEvent(Events.VIEWER_LOADED);
     window.parent.postMessage(
@@ -182,8 +175,6 @@ const App = ({
           <RightPanel dataElement="notesPanel" onResize={width => dispatch(actions.setNotesPanelWidth(width))}>
             <NotesPanel
               shareTypeColors={shareTypeColors}
-              setNotesShareType={setNotesShareType}
-              notesShareTypesMap={notesShareTypesMap}
             />
           </RightPanel>
         </div>
@@ -213,7 +204,6 @@ const App = ({
         <ContentEditModal />
         <FilterAnnotModal
           coAssessors={coAssessors}
-          notesShareTypesMap={notesShareTypesMap}
           shareTypeColors={shareTypeColors}
         />
         <CustomModal />

--- a/src/components/FilterAnnotModal/FilterAnnotModal.js
+++ b/src/components/FilterAnnotModal/FilterAnnotModal.js
@@ -11,6 +11,7 @@ import core from 'core';
 import actions from 'actions';
 import selectors from 'selectors';
 import fireEvent from 'helpers/fireEvent';
+import { getAnnotationShareType } from 'helpers/annotationShareType';
 import { rgbaToHex, hexToRgba } from 'helpers/color';
 import { getAnnotationClass } from 'helpers/getAnnotationClass';
 
@@ -106,8 +107,8 @@ const FilterAnnotModal = ({ coAssessors, shareTypeColors }) => {
         }
         if (shareTypeFilter.length > 0) {
           // CUSTOM WISEFLOW: get customData sharetype
-          if (annot.getCustomData('sharetype')) {
-            sharetype = shareTypeFilter.includes(annot.getCustomData('sharetype'));
+          if (getAnnotationShareType(annot)) {
+            sharetype = shareTypeFilter.includes(getAnnotationShareType(annot));
           }
         }
         return type && author && color && sharetype;
@@ -155,7 +156,7 @@ const FilterAnnotModal = ({ coAssessors, shareTypeColors }) => {
     const authorsToBeAdded = new Set();
     const annotTypesToBeAdded = new Set();
     const annotColorsToBeAdded = new Set();
-    const annotStatusesToBeAdded = new Set();
+    const annotShareTypesToBeAdded = new Set();
     annots.forEach(annot => {
       const displayAuthor = core.getDisplayAuthor(annot['Author']);
       if (displayAuthor && displayAuthor !== '') {
@@ -175,8 +176,8 @@ const FilterAnnotModal = ({ coAssessors, shareTypeColors }) => {
         annotColorsToBeAdded.add(rgbaToHex(iconColor.R, iconColor.G, iconColor.B, iconColor.A));
       }
 
-      if (notesShareTypesMap[annot.Id]) {
-        annotStatusesToBeAdded.add(notesShareTypesMap[annot.Id]);
+      if (getAnnotationShareType(annot)) {
+        annotShareTypesToBeAdded.add(getAnnotationShareType(annot));
       }
     });
 

--- a/src/components/FilterAnnotModal/FilterAnnotModal.js
+++ b/src/components/FilterAnnotModal/FilterAnnotModal.js
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import defaultTool from 'constants/defaultTool';
 import Events from 'constants/events';
+import ShareTypes from 'constants/shareTypes';
 import { mapAnnotationToKey } from 'constants/map';
 import core from 'core';
 import actions from 'actions';
@@ -22,7 +23,7 @@ import { FocusTrap } from '@pdftron/webviewer-react-toolkit';
 import './FilterAnnotModal.scss';
 import getDisplayAuthor from 'src/core/getDisplayAuthor';
 
-const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) => {
+const FilterAnnotModal = ({ coAssessors, shareTypeColors }) => {
   const [isDisabled, isOpen, colorMap] = useSelector(state => [
     selectors.isElementDisabled(state, 'filterModal'),
     selectors.isElementOpen(state, 'filterModal'),
@@ -34,13 +35,13 @@ const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) 
   const [authors, setAuthors] = useState([]);
   const [annotTypes, setAnnotTypes] = useState([]);
   const [colors, setColorTypes] = useState([]);
-  const [statuses, setStatusTypes] = useState(['Participants', 'Assessors', 'All', 'None']);
 
   const [authorFilter, setAuthorFilter] = useState([]);
   const [typesFilter, setTypesFilter] = useState([]);
   const [colorFilter, setColorFilter] = useState([]);
   const [checkRepliesForAuthorFilter, setCheckRepliesForAuthorFilter] = useState(true);
-  const [statusFilter, setStatusFilter] = useState([]);
+  // CUSTOM WISEFLOW: sharetype filter
+  const [shareTypeFilter, setShareTypeFilter] = useState([]);
   const [coAssessorFilter, setCoAssessorFilter] = useState([]);
 
   const getIconColor = annot => {
@@ -76,7 +77,7 @@ const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) 
         let type = true;
         let author = true;
         let color = true;
-        let status = true;
+        let sharetype = true;
         if (typesFilter.length > 0) {
           type = typesFilter.includes(getAnnotationClass(annot));
         }
@@ -103,21 +104,20 @@ const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) 
             color = colorFilter.includes('#485056');
           }
         }
-        if (statusFilter.length > 0) {
-          if (annot.getStatus()) {
-            status = statusFilter.includes(notesShareTypesMap[annot.Id]);
-          } else {
-            status = statusFilter.includes('None');
+        if (shareTypeFilter.length > 0) {
+          // CUSTOM WISEFLOW: get customData sharetype
+          if (annot.getCustomData('sharetype')) {
+            sharetype = shareTypeFilter.includes(annot.getCustomData('sharetype'));
           }
         }
-        return type && author && color && status;
+        return type && author && color && sharetype;
       }),
     );
     fireEvent(Events.ANNOTATION_FILTER_CHANGED, {
       types: typesFilter,
       authors: authorFilter,
       colors: colorFilter,
-      statuses: statusFilter,
+      shareTypes: shareTypeFilter,
       checkRepliesForAuthorFilter,
     });
     closeModal();
@@ -133,7 +133,7 @@ const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) 
     setAuthorFilter([]);
     setTypesFilter([]);
     setColorFilter([]);
-    setStatusFilter([]);
+    setShareTypeFilter([]);
     fireEvent('annotationFilterChanged', {
       types: [],
       authors: [],
@@ -299,12 +299,12 @@ const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) 
       <div className="filter">
         <div className="heading">{t('option.filterAnnotModal.shareType')}</div>
         <div className="buttons" style={{ gridTemplateColumns: `114px 100px` }}>
-          {[...statuses].map((val, index) => {
+          {[...Object.keys(ShareTypes)].map((val, index) => {
             return (
               <Choice
                 type="checkbox"
                 key={index}
-                checked={statusFilter.includes(val)}
+                checked={shareTypeFilter.includes(val)}
                 label={
                   <div
                     style={{
@@ -319,10 +319,10 @@ const FilterAnnotModal = ({ coAssessors, notesShareTypesMap, shareTypeColors }) 
                 }
                 id={val}
                 onChange={e => {
-                  if (statusFilter.indexOf(e.target.getAttribute('id')) === -1) {
-                    setStatusFilter([...statusFilter, e.target.getAttribute('id')]);
+                  if (shareTypeFilter.indexOf(e.target.getAttribute('id')) === -1) {
+                    setShareTypeFilter([...shareTypeFilter, e.target.getAttribute('id')]);
                   } else {
-                    setStatusFilter(statusFilter.filter(status => status !== e.target.getAttribute('id')));
+                    setShareTypeFilter(shareTypeFilter.filter(status => status !== e.target.getAttribute('id')));
                   }
                 }}
               />

--- a/src/components/FilterAnnotModal/FilterAnnotModal.scss
+++ b/src/components/FilterAnnotModal/FilterAnnotModal.scss
@@ -12,7 +12,7 @@
     align-items: center;
     border-radius: 4px;
     box-shadow: 0px 0px 3px 0px var(--document-box-shadow);
-    padding: 8px 8px;
+    padding: 1em;
     background: var(--component-background);
 
     @include mobile {
@@ -91,7 +91,8 @@
           }
 
           label {
-            overflow: hidden;
+            // Custom wiseflow
+            // overflow: hidden;
             text-overflow: ellipsis;
           }
         }

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -16,6 +16,8 @@ import useDidUpdate from 'hooks/useDidUpdate';
 import Button from 'components/Button';
 
 import './Note.scss';
+import { getAnnotationShareType } from 'src/helpers/annotationShareType';
+import ShareTypes from 'src/constants/shareTypes';
 
 const propTypes = {
   annotation: PropTypes.object.isRequired,
@@ -23,7 +25,7 @@ const propTypes = {
 
 let currId = 0;
 
-const Note = ({ annotation, shareTypeColors, setNotesShareType, notesShareTypesMap }) => {
+const Note = ({ annotation, shareTypeColors }) => {
   const {
     isSelected,
     resize,
@@ -38,21 +40,17 @@ const Note = ({ annotation, shareTypeColors, setNotesShareType, notesShareTypesM
   const containerHeightRef = useRef();
   const [isEditingMap, setIsEditingMap] = useState({});
   const [share, setShare] = useState({});
-  const getAnnotaionStatusColor = () => {
-    switch (notesShareTypesMap[annotation.Id]) {
-      case 'Assessors':
+  const getAnnotationStatusColor = () => {
+    switch (getAnnotationShareType(annotation)) {
+      case ShareTypes.ASSESSORS:
         return shareTypeColors.assessors;
-        break;
-      case 'Participants':
+      case ShareTypes.PARTICIPANTS:
         return shareTypeColors.participants;
-        break;
-      case 'All':
+      case ShareTypes.ALL:
         return shareTypeColors.all;
-        break;
-      case 'None':
+      case ShareTypes.NONE:
       default:
         return shareTypeColors.none;
-        break;
     }
   };
   const ids = useRef([]);
@@ -242,8 +240,8 @@ const Note = ({ annotation, shareTypeColors, setNotesShareType, notesShareTypesM
       onKeyDown={handleNoteKeydown}
       id={`note_${annotation.Id}`}
       style={{
-        borderBottom: `4px solid ${getAnnotaionStatusColor()}`,
-        borderTop: `4px solid ${getAnnotaionStatusColor()}`,
+        borderBottom: `4px solid ${getAnnotationStatusColor()}`,
+        borderTop: `4px solid ${getAnnotationStatusColor()}`,
       }}
     >
       <NoteContent
@@ -257,8 +255,6 @@ const Note = ({ annotation, shareTypeColors, setNotesShareType, notesShareTypesM
         onTextChange={setPendingEditText}
         isNonReplyNoteRead={!unreadAnnotationIdSet.has(annotation.Id)}
         isUnread={unreadAnnotationIdSet.has(annotation.Id) || hasUnreadReplies}
-        notesShareTypesMap={notesShareTypesMap}
-        setNotesShareType={setNotesShareType}
       />
       {(isSelected || isExpandedFromSearch) && (
         <React.Fragment>

--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -39,8 +39,6 @@ const NoteContent = ({
   isUnread,
   isNonReplyNoteRead,
   onReplyClicked,
-  notesShareTypesMap,
-  setNotesShareType,
 }) => {
   const [noteDateFormat, iconColor, isNoteStateDisabled, language, notesShowLastUpdatedDate] = useSelector(
     state => [
@@ -264,8 +262,6 @@ const NoteContent = ({
         isEditing={isEditing}
         noteIndex={noteIndex}
         sortStrategy={sortStrategy}
-        notesShareTypesMap={notesShareTypesMap}
-        setNotesShareType={setNotesShareType}
       />
     );
   }, [

--- a/src/components/NoteHeader/NoteHeader.js
+++ b/src/components/NoteHeader/NoteHeader.js
@@ -34,8 +34,6 @@ const propTypes = {
   isEditing: PropTypes.bool,
   noteIndex: PropTypes.number,
   sortStrategy: PropTypes.string,
-  notesShareTypesMap: PropTypes.object,
-  setNotesShareType: PropTypes.func,
 };
 
 function NoteHeader(props) {
@@ -56,8 +54,6 @@ function NoteHeader(props) {
     isEditing,
     noteIndex,
     sortStrategy,
-    notesShareTypesMap,
-    setNotesShareType,
   } = props;
 
   const [t] = useTranslation();
@@ -130,8 +126,6 @@ function NoteHeader(props) {
                 isSelected={isSelected}
                 share={share}
                 noteIndex={noteIndex}
-                notesShareTypesMap={notesShareTypesMap}
-                setNotesShareType={setNotesShareType}
               />
             )}
             {!isEditing && isSelected && (

--- a/src/components/NoteState/NoteState.js
+++ b/src/components/NoteState/NoteState.js
@@ -7,8 +7,10 @@ import Tooltip from '../Tooltip';
 
 import DataElementWrapper from 'components/DataElementWrapper';
 import Icon from 'components/Icon';
+import ShareTypes from 'constants/shareTypes';
 
 import './NoteState.scss';
+import { getAnnotationShareType, setAnnotationShareType } from 'src/helpers/annotationShareType';
 
 const propTypes = {
   annotation: PropTypes.object,
@@ -17,8 +19,6 @@ const propTypes = {
   handleStateChange: PropTypes.func,
   share: PropTypes.object,
   noteIndex: PropTypes.number,
-  notesShareTypesMap: PropTypes.object,
-  setNotesShareType: PropTypes.func,
 };
 
 function NoteState(props) {
@@ -29,9 +29,7 @@ function NoteState(props) {
     handleStateChange,
     share,
     noteIndex,
-    notesShareTypesMap,
     annotationId,
-    setNotesShareType,
   } = props;
 
   const [t] = useTranslation();
@@ -51,14 +49,14 @@ function NoteState(props) {
     setIsOpen(false);
   }
   const getStatusIcon = () => {
-    switch (notesShareTypesMap[annotation.Id]) {
-      case 'Assessors':
+    switch (getAnnotationShareType(annotation)) {
+      case ShareTypes.ASSESSORS:
         return 'icon-page-insertion-insert-above';
-      case 'Participants':
+      case ShareTypes.PARTICIPANTS:
         return 'icon-tool-stamp-fill';
-      case 'All':
+      case ShareTypes.ALL:
         return 'ic_annotation_apply_redact_black_24px';
-      case 'None':
+      case ShareTypes.NONE:
       default:
         return 'icon-annotation-status-none';
     }
@@ -67,7 +65,7 @@ function NoteState(props) {
     return function onStateOptionButtonClick() {
       if (handleStateChange) {
         handleStateChange(state);
-        setNotesShareType(state, annotation.Id);
+        setAnnotationShareType(annotation, state);
       }
     };
   }
@@ -102,7 +100,7 @@ function NoteState(props) {
             <DataElementWrapper
               dataElement="notePopupState-assessor"
               className="note-state-option"
-              onClick={createOnStateOptionButtonClickHandler('Assessors')}
+              onClick={createOnStateOptionButtonClickHandler(ShareTypes.ASSESSORS)}
             >
               <Icon glyph="icon-page-insertion-insert-above" />
               {t('option.state.assessors')}
@@ -111,7 +109,7 @@ function NoteState(props) {
             <DataElementWrapper
               dataElement="notePopupStateParticipants"
               className="note-state-option"
-              onClick={createOnStateOptionButtonClickHandler('Participants')}
+              onClick={createOnStateOptionButtonClickHandler(ShareTypes.PARTICIPANTS)}
             >
               <Icon glyph="icon-tool-stamp-fill" />
               {t('option.state.participants')}
@@ -120,7 +118,7 @@ function NoteState(props) {
             <DataElementWrapper
               dataElement="notePopupStateAll"
               className="note-state-option"
-              onClick={createOnStateOptionButtonClickHandler('All')}
+              onClick={createOnStateOptionButtonClickHandler(ShareTypes.ALL)}
             >
               <Icon glyph="ic_annotation_apply_redact_black_24px" />
               {t('option.state.all')}
@@ -129,7 +127,7 @@ function NoteState(props) {
             <DataElementWrapper
               dataElement="notePopupStateAssessors"
               className="note-state-option"
-              onClick={createOnStateOptionButtonClickHandler('None')}
+              onClick={createOnStateOptionButtonClickHandler(ShareTypes.NONE)}
             >
               <Icon glyph="icon-colour-none" />
               {t('option.state.none')}

--- a/src/components/NoteState/NoteStateContainer.js
+++ b/src/components/NoteState/NoteStateContainer.js
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import core from 'core';
 
 import NoteState from './NoteState';
+import { setAnnotationShareType } from 'src/helpers/annotationShareType';
+import getAnnotationManager from 'src/core/getAnnotationManager';
 
 function createStateAnnotation(t, annotation, state) {
   // TODO: the code below is copied from annotManager.updateAnnotationState in WebViewer to work around the issue
@@ -42,15 +44,9 @@ function NoteStateContainer(props) {
 
   const handleStateChange = React.useCallback(
     function handleStateChangeCallback(newValue) {
-      const stateAnnotation = createStateAnnotation(t, annotation, newValue);
-      annotation.addReply(stateAnnotation);
-      const annotationManager = core.getAnnotationManager();
-      annotationManager.addAnnotation(stateAnnotation);
-      annotationManager.trigger('addReply', [
-        stateAnnotation,
-        annotation,
-        annotationManager.getRootAnnotation(annotation),
-      ]);
+      // CUSTOM WISEFLOW: Set custom data value called sharetype and trigger annotationChanged event
+      setAnnotationShareType(annotation, newValue);
+      getAnnotationManager().trigger('annotationChanged', [[annotation], 'modify', {}]);
     },
     [annotation],
   );

--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -23,7 +23,7 @@ import fireEvent from 'helpers/fireEvent';
 import { debounce } from 'lodash';
 import './NotesPanel.scss';
 
-const NotesPanel = ({ currentLeftPanelWidth, shareTypeColors, setNotesShareType, notesShareTypesMap }) => {
+const NotesPanel = ({ currentLeftPanelWidth, shareTypeColors }) => {
   const [
     sortStrategy,
     isOpen,
@@ -107,8 +107,8 @@ const NotesPanel = ({ currentLeftPanelWidth, shareTypeColors, setNotesShareType,
     };
 
     const toggleFilterStyle = e => {
-      const { types, authors, colors, statuses } = e.detail;
-      if (types.length > 0 || authors.length > 0 || colors.length > 0 || statuses.length > 0) {
+      const { types, authors, colors, shareTypes } = e.detail;
+      if (types.length > 0 || authors.length > 0 || colors.length > 0 || shareTypes.length > 0) {
         setFilterEnabled(true);
       } else {
         setFilterEnabled(false);

--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -335,8 +335,6 @@ const NotesPanel = ({ currentLeftPanelWidth, shareTypeColors }) => {
           <Note
             annotation={currNote}
             shareTypeColors={shareTypeColors}
-            setNotesShareType={setNotesShareType}
-            notesShareTypesMap={notesShareTypesMap}
           />
         </NoteContext.Provider>
       </div>

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -70,7 +70,7 @@ export default {
  * @property {string[]} types Types filter
  * @property {string[]} authors Author filter
  * @property {string[]} colors Color filter
- * @property {string[]} statuses Status filter
+ * @property {string[]} shareTypes Status filter
  */
 
 /**

--- a/src/constants/shareTypes.js
+++ b/src/constants/shareTypes.js
@@ -1,1 +1,9 @@
-export const shareTypes = ['Assessors', 'Participants', 'All', 'None'];
+// CUSTOM WISEFLOW sharetype types.
+const ShareTypes = {
+  ASSESSORS: 'ASSESSORS',
+  PARTICIPANTS: 'PARTICIPANTS',
+  ALL: 'ALL',
+  NONE: 'NONE',
+};
+
+export default ShareTypes;

--- a/src/helpers/annotationShareType.js
+++ b/src/helpers/annotationShareType.js
@@ -1,0 +1,22 @@
+// CUSTOM WISEflow
+
+/**
+ * Get share type using custom data type "sharetype"
+ * @param {Annotation} annot annotation to add share type to
+ * @return {string} share type [ASSESSORS, PARTICIPANTS, ALL, NONE]. If none is set, returns empty string.
+ */
+const getAnnotationShareType = annot => annot.getCustomData('sharetype');
+
+/**
+ * Get share type using custom data type "sharetype"
+ * @param {Annotation} annot
+ * @param {string} shareType [ASSESSORS, PARTICIPANTS, ALL, NONE]
+ * 
+ * @returns {Annotation} annot with share type set
+ */
+const setAnnotationShareType = (annot, shareType) => {
+  annot.setCustomData('sharetype', shareType);
+  return annot;
+}
+
+export { getAnnotationShareType, setAnnotationShareType };


### PR DESCRIPTION
Removed the inner node sharetype state map and instead sets and reads the annotation share type via a custom data point ([Annotation.getCustomData](https://www.pdftron.com/api/web/Core.Annotations.Annotation.html#getCustomData__anchor)).

@naueramant 
Below is an example of the exported modification. Notice the `trn-custom-data`, `bytes` param. It should be parsed to get the sharetype. Notice html entities as well.
```
<square xmlns="http://ns.adobe.com/xfdf/" page="0" rect="514,772.110,561.570,817.730" color="#BBE7B7" flags="print" name="447c49b7-5e50-4b13-adc8-c291102466e6" title="1337" subject="Rectangle" date="D:20220422103408+02'00'" width="5" creationdate="D:20171226120147-08'00'">
  <trn-custom-data bytes="{&quot;sharetype&quot;:&quot;PARTICIPANTS&quot;}" />
</square>
```