### PR TITLE
FEAT-4075 - UI ability to change share type on shared annotations

### DIFF
--- a/src/components/NoteState/NoteState.js
+++ b/src/components/NoteState/NoteState.js
@@ -5,12 +5,15 @@ import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import Tooltip from '../Tooltip';
 
+import core from 'core';
+
 import DataElementWrapper from 'components/DataElementWrapper';
 import ShareTypes from 'constants/shareTypes';
 import ShareTypeIcon from './ShareTypeIcon';
 
 import './NoteState.scss';
-import { getAnnotationShareType, setAnnotationShareType } from 'src/helpers/annotationShareType';
+
+import { getAnnotationShareType } from 'src/helpers/annotationShareType';
 
 const propTypes = {
   annotation: PropTypes.object,
@@ -36,6 +39,8 @@ function NoteState(props) {
   const [isOpen, setIsOpen] = useState(openOnInitialLoad);
   const popupRef = useRef();
 
+  const isOwnedByCurrentUser = annotation.Author === core.getCurrentUser();
+
   useOnClickOutside(popupRef, () => {
     setIsOpen(false);
   });
@@ -48,14 +53,18 @@ function NoteState(props) {
   function onStateOptionsButtonClick() {
     setIsOpen(false);
   }
-  const getShareTypeIcon = (shareType) => {
+
+  const getShareTypeIcon = shareType => {
     return <ShareTypeIcon shareType={shareType} />;
   };
+
   function createOnStateOptionButtonClickHandler(state) {
+    // If not current author, do not allow state change
+    if (!isOwnedByCurrentUser) return;
+
     return function onStateOptionButtonClick() {
       if (handleStateChange) {
         handleStateChange(state);
-        setAnnotationShareType(annotation, state);
       }
     };
   }
@@ -80,11 +89,18 @@ function NoteState(props) {
   const noteStateButtonClassName = classNames('overflow', { active: isOpen });
   return (
     <DataElementWrapper className="NoteState" dataElement="noteState" onClick={togglePopup} ref={popupRef}>
-      <Tooltip translatedContent={`${t('option.notesOrder.shareType')}: ${t(`option.state.${annotationShareType.toLowerCase()}`)}`}>
+      <Tooltip
+        translatedContent={`${t('option.notesOrder.shareType')}: ${t(
+          `option.state.${annotationShareType.toLowerCase()}`,
+        )}`}
+      >
         <div className={noteStateButtonClassName}>{icon}</div>
       </Tooltip>
       {isOpen && (
-        <button className="note-state-options" onClick={onStateOptionsButtonClick}>
+        <button
+          className={`note-state-options ${isOwnedByCurrentUser ? 'enabled' : 'disabled'}`}
+          onClick={onStateOptionsButtonClick}
+        >
           <DataElementWrapper dataElement="notePopupState">
             <DataElementWrapper
               dataElement="notePopupState-assessor"

--- a/src/components/NoteState/NoteState.scss
+++ b/src/components/NoteState/NoteState.scss
@@ -69,10 +69,6 @@
         background-color: var(--popup-button-active);
       }
 
-      &:hover {
-        background-color: var(--popup-button-hover);
-      }
-
       &:first-child {
         border-top-right-radius: 4px;
         border-top-left-radius: 4px;
@@ -81,6 +77,14 @@
       &:last-child {
         border-bottom-right-radius: 4px;
         border-bottom-right-radius: 4px;
+      }
+    }
+
+    &.enabled .note-state-option {
+      cursor: pointer;
+
+      &:hover {
+        background-color: var(--popup-button-hover);
       }
     }
   }

--- a/src/components/NoteState/NoteStateContainer.js
+++ b/src/components/NoteState/NoteStateContainer.js
@@ -45,6 +45,8 @@ function NoteStateContainer(props) {
   const handleStateChange = React.useCallback(
     function handleStateChangeCallback(newValue) {
       // CUSTOM WISEFLOW: Set custom data value called sharetype and trigger annotationChanged event
+
+      // Set share type and trigger annotationChanged "modify" event
       setAnnotationShareType(annotation, newValue);
       getAnnotationManager().trigger('annotationChanged', [[annotation], 'modify', {}]);
     },


### PR DESCRIPTION
Disable setting share type if annotation is not owned by the current user (i.e. shared annotations).
Visually, disabled the menu items so that they do not look active and usable