### PR TITLE
Feat 5000 make it possible to overwrite insert text here instead of having to delete it

### DIFF
--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -22,18 +22,24 @@ import selectors from 'selectors';
 import './AnnotationPopup.scss';
 
 const AnnotationPopup = () => {
-  const [isDisabled, isOpen, isNotesPanelDisabled, isAnnotationStylePopupDisabled, popupItems, isNotesPanelOpen] =
-    useSelector(
-      state => [
-        selectors.isElementDisabled(state, 'annotationPopup'),
-        selectors.isElementOpen(state, 'annotationPopup'),
-        selectors.isElementDisabled(state, 'notesPanel'),
-        selectors.isElementDisabled(state, 'annotationStylePopup'),
-        selectors.getPopupItems(state, 'annotationPopup'),
-        selectors.isElementOpen(state, 'notesPanel'),
-      ],
-      shallowEqual,
-    );
+  const [
+    isDisabled,
+    isOpen,
+    isNotesPanelDisabled,
+    isAnnotationStylePopupDisabled,
+    popupItems,
+    isNotesPanelOpen,
+  ] = useSelector(
+    state => [
+      selectors.isElementDisabled(state, 'annotationPopup'),
+      selectors.isElementOpen(state, 'annotationPopup'),
+      selectors.isElementDisabled(state, 'notesPanel'),
+      selectors.isElementDisabled(state, 'annotationStylePopup'),
+      selectors.getPopupItems(state, 'annotationPopup'),
+      selectors.isElementOpen(state, 'notesPanel'),
+    ],
+    shallowEqual,
+  );
   const dispatch = useDispatch();
   const [t] = useTranslation();
   const [position, setPosition] = useState({ left: 0, top: 0 });
@@ -52,16 +58,14 @@ const AnnotationPopup = () => {
 
   // helper function to get all the link annotations that are grouped with the passed in annotation
   const getGroupedLinkAnnotations = annotation => {
-    const groupedLinks = core
-      .getAnnotationManager()
-      .getGroupAnnotations(annotation)
-      .filter(groupedAnnotation => {
-        return groupedAnnotation instanceof Annotations.Link;
-      });
+    const groupedLinks = core.getAnnotationManager().getGroupAnnotations(annotation).filter(groupedAnnotation => {
+      return groupedAnnotation instanceof Annotations.Link;
+    });
     return groupedLinks;
   };
 
   useOnClickOutside(popupRef, e => {
+
     const notesPanel = document.querySelector('[data-element="notesPanel"]');
     const clickedInNotesPanel = notesPanel?.contains(e.target);
     const datePicker = getDatePicker();
@@ -207,18 +211,15 @@ const AnnotationPopup = () => {
   const multipleAnnotationsSelected = numberOfSelectedAnnotations > 1;
 
   const isFreeTextAnnot = firstAnnotation instanceof window.Annotations.FreeTextAnnotation;
-  const isFreeTextAndCanEdit =
-    isFreeTextAnnot &&
-    core.getAnnotationManager().isFreeTextEditingEnabled() &&
-    core.canModifyContents(firstAnnotation);
-  const isDateFreeTextCanEdit =
-    isFreeTextAnnot && firstAnnotation.getDateFormat() && core.canModifyContents(firstAnnotation);
+  const isFreeTextAndCanEdit = isFreeTextAnnot && core.getAnnotationManager().isFreeTextEditingEnabled() && core.canModifyContents(firstAnnotation);
+  const isDateFreeTextCanEdit = isFreeTextAnnot && firstAnnotation.getDateFormat() && core.canModifyContents(firstAnnotation);
 
   const commentOnAnnotation = () => {
     if (isDateFreeTextCanEdit) {
       toggleDatePicker();
       return;
-    } else {
+    }
+    else {
       dispatch(actions.openElement('notesPanel'));
       dispatch(actions.closeElement('searchPanel'));
       dispatch(actions.triggerNoteEditing());
@@ -231,19 +232,11 @@ const AnnotationPopup = () => {
     core.getAnnotationManager().updateAnnotation(firstAnnotation);
   };
   const ShortCutKeysFor3DComponent = () => {
-    return (
-      <div className="shortCuts3D">
-        <div className="closeButton" onClick={() => setShortCutKeysFor3DVisible(false)}>
-          x
-        </div>
-        <div className="row">
-          {t('action.rotate3D')} <span>{t('shortcut.rotate3D')}</span>
-        </div>
-        <div className="row">
-          {t('action.zoom')} <span>{t('shortcut.zoom3D')}</span>
-        </div>
-      </div>
-    );
+    return (<div className="shortCuts3D">
+      <div className="closeButton" onClick={() => setShortCutKeysFor3DVisible(false)}>x</div>
+      <div className="row">{t('action.rotate3D')} <span>{t('shortcut.rotate3D')}</span></div>
+      <div className="row">{t('action.zoom')} <span>{t('shortcut.zoom3D')}</span></div>
+    </div>);
   };
 
   const downloadFileAttachment = annot => {
@@ -259,7 +252,11 @@ const AnnotationPopup = () => {
   };
 
   const toolNames = window.Core.Tools.ToolNames;
-  const toolsWithNoStyling = [toolNames.CROP, toolNames.RADIO_FORM_FIELD, toolNames.CHECK_BOX_FIELD];
+  const toolsWithNoStyling = [
+    toolNames.CROP,
+    toolNames.RADIO_FORM_FIELD,
+    toolNames.CHECK_BOX_FIELD,
+  ];
 
   const toolsThatCantHaveLinks = [
     toolNames.CROP,
@@ -286,8 +283,7 @@ const AnnotationPopup = () => {
     hasStyle &&
     !isAnnotationStylePopupDisabled &&
     (!multipleAnnotationsSelected || canUngroup) &&
-    !toolsWithNoStyling.includes(firstAnnotation.ToolName) &&
-    !(firstAnnotation instanceof Annotations.Model3DAnnotation) &&
+    !toolsWithNoStyling.includes(firstAnnotation.ToolName) && !(firstAnnotation instanceof Annotations.Model3DAnnotation) &&
     !firstAnnotation.isContentEditPlaceholder();
 
   const showRedactionButton = redactionEnabled && !multipleAnnotationsSelected && !includesFormFieldAnnotation;
@@ -298,17 +294,19 @@ const AnnotationPopup = () => {
     canModify && firstAnnotation.Measure && firstAnnotation instanceof Annotations.LineAnnotation;
 
   const showFileDownloadButton = firstAnnotation instanceof window.Annotations.FileAttachmentAnnotation;
-  const shouldShowAudioPlayButton =
+  const shouldShowAudioPlayButton = (
     !isIE &&
     !selectedMultipleAnnotations &&
     firstAnnotation instanceof window.Annotations.SoundAnnotation &&
-    firstAnnotation.hasAudioData();
+    firstAnnotation.hasAudioData()
+  );
 
-  const showLinkButton =
+  const showLinkButton = (
     !toolsThatCantHaveLinks.includes(firstAnnotation.ToolName) &&
     !includesFormFieldAnnotation &&
     !firstAnnotation.isContentEditPlaceholder() &&
-    !(firstAnnotation instanceof Annotations.SoundAnnotation); // TODO(Adam): Update this once SoundAnnotation tool is created.
+    !(firstAnnotation instanceof Annotations.SoundAnnotation) // TODO(Adam): Update this once SoundAnnotation tool is created.
+  );
 
   const onDatePickerShow = isDatePickerShowed => {
     setDatePickerMount(isDatePickerShowed);
@@ -318,7 +316,7 @@ const AnnotationPopup = () => {
 
   const onResize = () => {
     setStylePopupRepositionFlag(!stylePopupRepositionFlag);
-  };
+  }
 
   const annotationPopup = (
     <div
@@ -339,40 +337,37 @@ const AnnotationPopup = () => {
         ) : (
           <DatePicker onClick={handleDateChange} annotation={firstAnnotation} onDatePickerShow={onDatePickerShow} />
         )
-      ) : shortCutKeysFor3DVisible && firstAnnotation instanceof Annotations.Model3DAnnotation ? (
-        <ShortCutKeysFor3DComponent />
-      ) : (
-        <CustomizablePopup dataElement="annotationPopup">
-          {showCommentButton && (
-            <ActionButton
-              dataElement="annotationCommentButton"
-              title="action.openNotePanel"
-              // CUSTOM WISEFLOW: Changed icon
-              img="circle-right-solid"
-              onClick={commentOnAnnotation}
-            />
-          )}
-          {showEditStyleButton && (
-            <ActionButton
-              dataElement="annotationStyleEditButton"
-              title="action.style"
-              img="icon-menu-style-line"
-              onClick={() => setIsStylePopupOpen(true)}
-            />
-          )}
-          {firstAnnotation.ToolName === 'CropPage' && (
-            <ActionButton
-              dataElement="annotationCropButton"
-              title="action.apply"
-              img="ic_check_black_24px"
-              onClick={() => {
-                core.getTool('CropPage').applyCrop();
-                dispatch(actions.closeElement('annotationPopup'));
-              }}
-            />
-          )}
-          {firstAnnotation.isContentEditPlaceholder() &&
-            firstAnnotation.getContentEditType() === window.Core.ContentEdit.Types.TEXT && (
+      ) : (shortCutKeysFor3DVisible && firstAnnotation instanceof Annotations.Model3DAnnotation) ?
+        <ShortCutKeysFor3DComponent /> : (
+          <CustomizablePopup dataElement="annotationPopup">
+            {showCommentButton && (
+              <ActionButton
+                dataElement="annotationCommentButton"
+                title="action.comment"
+                img="circle-right-solid"
+                onClick={commentOnAnnotation}
+              />
+            )}
+            {showEditStyleButton && (
+              <ActionButton
+                dataElement="annotationStyleEditButton"
+                title="action.style"
+                img="icon-menu-style-line"
+                onClick={() => setIsStylePopupOpen(true)}
+              />
+            )}
+            {firstAnnotation.ToolName === 'CropPage' && (
+              <ActionButton
+                dataElement="annotationCropButton"
+                title="action.apply"
+                img="ic_check_black_24px"
+                onClick={() => {
+                  core.getTool('CropPage').applyCrop();
+                  dispatch(actions.closeElement('annotationPopup'));
+                }}
+              />
+            )}
+            {firstAnnotation.isContentEditPlaceholder() && firstAnnotation.getContentEditType() === window.Core.ContentEdit.Types.TEXT && (
               <ActionButton
                 dataElement="annotationContentEditButton"
                 title="action.edit"
@@ -385,83 +380,80 @@ const AnnotationPopup = () => {
                 }}
               />
             )}
-          {showRedactionButton && (
-            <ActionButton
-              dataElement="annotationRedactButton"
-              title="action.apply"
-              img="ic_check_black_24px"
-              onClick={() => {
-                dispatch(applyRedactions(firstAnnotation));
-                dispatch(actions.closeElement('annotationPopup'));
-              }}
-            />
-          )}
-          {showGroupButton && (
-            <ActionButton
-              dataElement="annotationGroupButton"
-              title="action.group"
-              img="ic_group_24px"
-              onClick={() => core.groupAnnotations(primaryAnnotation, selectedAnnotations)}
-            />
-          )}
-          {canUngroup && (
-            <ActionButton
-              dataElement="annotationUngroupButton"
-              title="action.ungroup"
-              img="ic_ungroup_24px"
-              onClick={() => core.ungroupAnnotations(selectedAnnotations)}
-            />
-          )}
-          {includesFormFieldAnnotation && (
-            <ActionButton
-              title="action.formFieldEdit"
-              img="icon-edit-form-field"
-              onClick={() => {
-                dispatch(actions.closeElement('annotationPopup'));
-                dispatch(actions.openElement('formFieldEditPopup'));
-              }}
-              dataElement="formFieldEditButton"
-            />
-          )}
-          {canModify && (
-            <ActionButton
-              dataElement="annotationDeleteButton"
-              title="action.delete"
-              img="icon-delete-line"
-              onClick={() => {
-                core.deleteAnnotations(core.getSelectedAnnotations());
-                dispatch(actions.closeElement('annotationPopup'));
-              }}
-            />
-          )}
-          {showCalibrateButton && (
-            <ActionButton
-              dataElement="calibrateButton"
-              title="action.calibrate"
-              img="calibrate"
-              onClick={() => {
-                dispatch(actions.closeElement('annotationPopup'));
-                dispatch(actions.openElement('calibrationModal'));
-              }}
-            />
-          )}
-          {/* {showLinkButton && (
-            <ActionButton
-              title="tool.Link"
-              img={hasAssociatedLink ? 'icon-tool-unlink' : 'icon-tool-link'}
-              onClick={
-                hasAssociatedLink
-                  ? () => {
+            {showRedactionButton && (
+              <ActionButton
+                dataElement="annotationRedactButton"
+                title="action.apply"
+                img="ic_check_black_24px"
+                onClick={() => {
+                  dispatch(applyRedactions(firstAnnotation));
+                  dispatch(actions.closeElement('annotationPopup'));
+                }}
+              />
+            )}
+            {showGroupButton && (
+              <ActionButton
+                dataElement="annotationGroupButton"
+                title="action.group"
+                img="ic_group_24px"
+                onClick={() => core.groupAnnotations(primaryAnnotation, selectedAnnotations)}
+              />
+            )}
+            {canUngroup && (
+              <ActionButton
+                dataElement="annotationUngroupButton"
+                title="action.ungroup"
+                img="ic_ungroup_24px"
+                onClick={() => core.ungroupAnnotations(selectedAnnotations)}
+              />
+            )}
+            {includesFormFieldAnnotation && (
+              <ActionButton
+                title="action.formFieldEdit"
+                img="icon-edit-form-field"
+                onClick={() => {
+                  dispatch(actions.closeElement('annotationPopup'));
+                  dispatch(actions.openElement('formFieldEditPopup'));
+                }}
+                dataElement="formFieldEditButton"
+              />
+            )
+            }
+            {canModify && (
+              <ActionButton
+                dataElement="annotationDeleteButton"
+                title="action.delete"
+                img="icon-delete-line"
+                onClick={() => {
+                  core.deleteAnnotations(core.getSelectedAnnotations());
+                  dispatch(actions.closeElement('annotationPopup'));
+                }}
+              />
+            )}
+            {showCalibrateButton && (
+              <ActionButton
+                dataElement="calibrateButton"
+                title="action.calibrate"
+                img="calibrate"
+                onClick={() => {
+                  dispatch(actions.closeElement('annotationPopup'));
+                  dispatch(actions.openElement('calibrationModal'));
+                }}
+              />
+            )}
+            {/* {showLinkButton && (
+              <ActionButton
+                title="tool.Link"
+                img={hasAssociatedLink ? 'icon-tool-unlink' : 'icon-tool-link'}
+                onClick={
+                  hasAssociatedLink
+                    ? () => {
                       const annotManager = core.getAnnotationManager();
                       selectedAnnotations.forEach(annot => {
                         const linkAnnotations = getGroupedLinkAnnotations(annot);
                         linkAnnotations.forEach((linkAnnot, index) => {
                           annotManager.ungroupAnnotations([linkAnnot]);
-                          if (
-                            annot instanceof Annotations.TextHighlightAnnotation &&
-                            annot.Opacity === 0 &&
-                            index === 0
-                          ) {
+                          if (annot instanceof Annotations.TextHighlightAnnotation && annot.Opacity === 0 && index === 0) {
                             annotManager.deleteAnnotations([annot, linkAnnot], null, true);
                           } else {
                             annotManager.deleteAnnotation(linkAnnot, null, true);
@@ -470,37 +462,45 @@ const AnnotationPopup = () => {
                       });
                       dispatch(actions.closeElement('annotationPopup'));
                     }
-                  : () => dispatch(actions.openElement('linkModal'))
-              }
-              dataElement="linkButton"
-            />
-          )} */}
-          {showFileDownloadButton && (
-            <ActionButton
-              title="action.fileAttachmentDownload"
-              img="icon-download"
-              onClick={() => downloadFileAttachment(firstAnnotation)}
-              dataElement="fileAttachmentDownload"
-            />
-          )}
-          {show3DShortCutButton && (
-            <ActionButton
-              title="action.viewShortCutKeysFor3D"
-              img="icon-keyboard"
-              onClick={() => setShortCutKeysFor3DVisible(true)}
-              dataElement="shortCutKeysFor3D"
-            />
-          )}
-          {shouldShowAudioPlayButton && (
-            <ActionButton
-              title="action.playAudio"
-              img="ic_play_24px"
-              onClick={() => handlePlaySound(firstAnnotation)}
-              dataElement="playSoundButton"
-            />
-          )}
-        </CustomizablePopup>
-      )}
+                    : () => dispatch(actions.openElement('linkModal'))
+                }
+                dataElement="linkButton"
+              />
+            )} */}
+            {showFileDownloadButton &&
+              (
+                <ActionButton
+                  title="action.fileAttachmentDownload"
+                  img="icon-download"
+                  onClick={() => downloadFileAttachment(firstAnnotation)}
+                  dataElement="fileAttachmentDownload"
+                />
+              )
+            }
+            {
+              show3DShortCutButton &&
+              (
+                <ActionButton
+                  title="action.viewShortCutKeysFor3D"
+                  img="icon-keyboard"
+                  onClick={() => setShortCutKeysFor3DVisible(true)}
+                  dataElement="shortCutKeysFor3D"
+                />
+              )
+            }
+            {
+              shouldShowAudioPlayButton &&
+              (
+                <ActionButton
+                  title="action.playAudio"
+                  img="ic_play_24px"
+                  onClick={() => handlePlaySound(firstAnnotation)}
+                  dataElement="playSoundButton"
+                />
+              )
+            }
+          </CustomizablePopup>
+        )}
     </div>
   );
 

--- a/src/event-listeners/onAnnotationChanged.js
+++ b/src/event-listeners/onAnnotationChanged.js
@@ -4,18 +4,17 @@ import getWiseflowCustomValues from 'helpers/getWiseflowCustomValues';
 import fireEvent from 'src/helpers/fireEvent';
 import Events from 'src/constants/events';
 import { setAnnotationShareType } from 'src/helpers/annotationShareType';
-import getAnnotationManager from 'core/getAnnotationManager';
-import ShareTypes from 'src/constants/shareTypes';
 
 export default () => (annotations, action, info) => {
   if (action === 'delete') {
     deleteReplies(annotations);
   }
 
-  const selectAnnotationOnCreation = getHashParameters('selectAnnotationOnCreation', false);
+  const selectAnnotationOnCreation = getHashParameters('selectAnnotationOnCreation', true);
   if (selectAnnotationOnCreation) {
     if (action === 'add' && !info.imported) {
-      if (annotations.length > 0 && !annotations[0].InReplyTo) {
+      const isFreeTextAnnot = annotations[0] instanceof window.Annotations.FreeTextAnnotation;
+      if (annotations.length > 0 && !annotations[0].InReplyTo && !isFreeTextAnnot) {
         core.selectAnnotation(annotations[0]);
       }
     }


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Fix freetext creation issue.


# What has changed?
Made exception for freetext so that it is not automatically select, on creation, making it so that the text is highlighted and can be edited at creation.

Reverted some formatting done in `src/components/AnnotationPopup/AnnotationPopup.js` in https://github.com/UNIwise/webviewer-ui/commit/31a6707c3a6c040abd4092b07973b9fbec2a07e3 to limit future merging issues.

# Notes for your reviewer

## Jira links

```jira_links

```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->