### PR TITLE
FEAT-5355 - Note cancel changes

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -123,8 +123,7 @@ const Note = ({ annotation }) => {
 
   useEffect(() => {
     //If this is not a new one, rebuild the isEditing map
-    const pendingText = pendingEditTextMap[annotation.Id];
-    if (pendingText !== '' && isContentEditable && !isDocumentReadOnly) {
+    if (annotation.getContents() === undefined && isContentEditable && !isDocumentReadOnly) {
       setIsEditing(true, 0);
     }
   }, [isDocumentReadOnly, isContentEditable, setIsEditing, annotation, pendingEditTextMap]);

--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -353,9 +353,9 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
           ids,
         }),
       );
-      core.setNoteContents(annotation, plainTextValue);
+      core.setNoteContents(annotation, plainTextValue ?? '');
     } else {
-      core.setNoteContents(annotation, textAreaValue);
+      core.setNoteContents(annotation, textAreaValue ?? '');
     }
 
     if (annotation instanceof window.Annotations.FreeTextAnnotation) {
@@ -370,7 +370,6 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
   };
 
   const contentClassName = classNames('edit-content', { 'reply-content': isReply });
-
   return (
     <div className={contentClassName}>
       <NoteTextarea
@@ -384,20 +383,21 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
         aria-label={`${t('action.comment')}...`}
       />
       <div className="edit-buttons">
+        {annotation.getContents() !== undefined && (
+          <button
+            className="cancel-button"
+            onClick={e => {
+              e.stopPropagation();
+              setIsEditing(false, noteIndex);
+              // Clear pending text
+              onTextAreaValueChange(undefined, annotation.Id);
+            }}
+          >
+            {t('action.cancel')}
+          </button>
+        )}
         <button
-          className="cancel-button"
-          onClick={e => {
-            e.stopPropagation();
-            setIsEditing(false, noteIndex);
-            // Clear pending text
-            onTextAreaValueChange('', annotation.Id);
-          }}
-        >
-          {t('action.cancel')}
-        </button>
-        <button
-          className={`save-button${!textAreaValue ? ' disabled' : ''}`}
-          disabled={!textAreaValue}
+          className={`save-button`}
           onClick={e => {
             e.stopPropagation();
             setContents(e);


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Fixes a bug introduced by https://github.com/UNIwise/webviewer-ui/pull/19, where cancelling would clear the local variant of the text for a note/annotation. Made some fixes to cancelling and saving, allowing the user to save an empty note (i.e. clearing the content).

# What has changed?
In useEffect that checks starts editing on new notes, check on content instead of pending text.
Send empty string instead of undefined on save.
Hide cancel button, when the note is new (as you can save it empty instead).

# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/FEAT-5355
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->