### PR TITLE
disable outline and signature panels

### DIFF
--- a/src/components/LeftPanelTabs/LeftPanelTabs.js
+++ b/src/components/LeftPanelTabs/LeftPanelTabs.js
@@ -39,14 +39,6 @@ class LeftPanelTabs extends React.Component {
           title="component.thumbnailsPanel"
         />
         <Button
-          disabled
-          isActive={this.isActive('outlinesPanel')}
-          dataElement="outlinesPanelButton"
-          img="icon-panel-outlines"
-          onClick={() => setActiveLeftPanel('outlinesPanel')}
-          title="component.outlinesPanel"
-        />
-        <Button
           isActive={this.isActive('layersPanel')}
           dataElement="layersPanelButton"
           img="ic_layers_24px"
@@ -59,14 +51,6 @@ class LeftPanelTabs extends React.Component {
           img="ic_bookmarks_black_24px"
           onClick={() => setActiveLeftPanel('bookmarksPanel')}
           title="component.bookmarksPanel"
-        />
-        <Button
-          disabled
-          isActive={this.isActive('signaturePanel')}
-          dataElement="signaturePanelButton"
-          img="icon-tool-signature"
-          onClick={() => setActiveLeftPanel('signaturePanel')}
-          title="component.signaturePanel"
         />
         <Button
           isActive={this.isActive('attachmentPanel')}

--- a/src/components/LeftPanelTabs/LeftPanelTabs.js
+++ b/src/components/LeftPanelTabs/LeftPanelTabs.js
@@ -23,12 +23,7 @@ class LeftPanelTabs extends React.Component {
   isActive = panel => this.props.activePanel === panel;
 
   render() {
-    const {
-      customPanels,
-      isLeftPanelTabsDisabled,
-      setActiveLeftPanel,
-      notesInLeftPanel,
-    } = this.props;
+    const { customPanels, isLeftPanelTabsDisabled, setActiveLeftPanel, notesInLeftPanel } = this.props;
 
     if (isLeftPanelTabsDisabled) {
       return null;
@@ -44,6 +39,7 @@ class LeftPanelTabs extends React.Component {
           title="component.thumbnailsPanel"
         />
         <Button
+          disabled
           isActive={this.isActive('outlinesPanel')}
           dataElement="outlinesPanelButton"
           img="icon-panel-outlines"
@@ -65,6 +61,7 @@ class LeftPanelTabs extends React.Component {
           title="component.bookmarksPanel"
         />
         <Button
+          disabled
           isActive={this.isActive('signaturePanel')}
           dataElement="signaturePanelButton"
           img="icon-tool-signature"
@@ -78,15 +75,16 @@ class LeftPanelTabs extends React.Component {
           onClick={() => setActiveLeftPanel('attachmentPanel')}
           title="component.attachmentPanel"
         />
-        {notesInLeftPanel &&
+        {notesInLeftPanel && (
           <Button
             isActive={this.isActive('notesPanel')}
             dataElement="notesPanelButton"
             img="icon-header-chat-line"
             onClick={() => setActiveLeftPanel('notesPanel')}
             title="component.notesPanel"
-          />}
-        {customPanels.map(({ panel, tab }, index) =>
+          />
+        )}
+        {customPanels.map(({ panel, tab }, index) => (
           <React.Fragment key={index}>
             <Button
               key={tab.dataElement || index}
@@ -97,8 +95,8 @@ class LeftPanelTabs extends React.Component {
               title={tab.title}
             />
             {index < customPanels.length - 1 && <div className="divider" />}
-          </React.Fragment>,
-        )}
+          </React.Fragment>
+        ))}
       </Element>
     );
   }
@@ -116,7 +114,4 @@ const mapDispatchToProps = {
   setActiveLeftPanel: actions.setActiveLeftPanel,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(withTranslation()(LeftPanelTabs));
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(LeftPanelTabs));


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
remove Signature and Outline btn in left pane as described in https://uniwise.atlassian.net/browse/FEAT-5757

# What has changed?
Remove signature and outline btns from the panes

## Jira links
https://uniwise.atlassian.net/browse/FEAT-5757