### PR TITLE
FEAT-5451 - Frontend participant annotation should not show the share type color in PDFtron

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -18,6 +18,7 @@ import Button from 'components/Button';
 import './Note.scss';
 import { getAnnotationShareType } from 'src/helpers/annotationShareType';
 import { ShareTypeColors } from 'src/constants/shareTypes';
+import getWiseflowCustomValues from 'helpers/getWiseflowCustomValues';
 
 const propTypes = {
   annotation: PropTypes.object.isRequired,
@@ -39,9 +40,13 @@ const Note = ({ annotation }) => {
   const containerRef = useRef();
   const containerHeightRef = useRef();
   const [isEditingMap, setIsEditingMap] = useState({});
+
   const getAnnotationStatusColor = () => {
     return ShareTypeColors[getAnnotationShareType(annotation)] ?? ShareTypeColors.NONE;
   };
+
+  const showShareType = getWiseflowCustomValues().showShareType;
+
   const ids = useRef([]);
   const dispatch = useDispatch();
   const [t] = useTranslation();
@@ -227,10 +232,14 @@ const Note = ({ annotation }) => {
       onClick={handleNoteClick}
       onKeyDown={handleNoteKeydown}
       id={`note_${annotation.Id}`}
-      style={{
-        borderBottom: `4px solid ${getAnnotationStatusColor()}`,
-        borderTop: `4px solid ${getAnnotationStatusColor()}`,
-      }}
+      style={
+        showShareType
+          ? {
+              borderBottom: `4px solid ${getAnnotationStatusColor()}`,
+              borderTop: `4px solid ${getAnnotationStatusColor()}`,
+            }
+          : undefined
+      }
     >
       <NoteContent
         noteIndex={0}

--- a/src/components/NoteHeader/NoteHeader.js
+++ b/src/components/NoteHeader/NoteHeader.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, memo } from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import NotePopup from 'components/NotePopup';
 import NoteState from 'components/NoteState';
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { NotesPanelSortStrategy } from 'constants/sortStrategies';
 import getAnnotationReference from 'src/helpers/getAnnotationReference';
+import getWiseflowCustomValues from 'helpers/getWiseflowCustomValues';
 
 import './NoteHeader.scss';
 import Tooltip from '../Tooltip';
@@ -26,12 +27,14 @@ const propTypes = {
   isSelected: PropTypes.bool,
   setIsEditing: PropTypes.func,
   notesShowLastUpdatedDate: PropTypes.bool,
+  isReply: PropTypes.bool,
   isUnread: PropTypes.bool,
   renderAuthorName: PropTypes.func,
   isNoteStateDisabled: PropTypes.bool,
   isEditing: PropTypes.bool,
   noteIndex: PropTypes.number,
   sortStrategy: PropTypes.string,
+  renderAnnotationReference: PropTypes.func,
 };
 
 function NoteHeader(props) {
@@ -63,6 +66,8 @@ function NoteHeader(props) {
       : annotation.DateCreated;
   const color = annotation[iconColor]?.toHexString?.();
   const fillColor = getColor(annotation.FillColor);
+
+  const showShareType = getWiseflowCustomValues().showShareType;
 
   const authorAndDateClass = classNames('author-and-date', { isReply });
   const noteHeaderClass = classNames('NoteHeader', { parent: !isReply });
@@ -118,7 +123,7 @@ function NoteHeader(props) {
 
           <div className="state-and-overflow">
             <NoteUnpostedCommentIndicator annotationId={annotation.Id} />
-            {!isNoteStateDisabled && !isReply && (
+            {!isNoteStateDisabled && showShareType && !isReply && (
               <NoteState annotation={annotation} isSelected={isSelected} noteIndex={noteIndex} />
             )}
             {!isEditing && isSelected && (

--- a/src/helpers/getWiseflowCustomValues.js
+++ b/src/helpers/getWiseflowCustomValues.js
@@ -3,14 +3,21 @@ import getCustomData from 'src/apis/getCustomData';
 import ShareTypes from 'src/constants/shareTypes';
 
 /**
- * @returns {{
- *  defaultShareType: string,
- * }}
+ * @typedef {Object} WiseflowCustomValues
+ * @property {string} defaultShareType (default: ShareTypes.NONE)
+ * @property {boolean} showShareType (default: true)
+ */
+
+/**
+ * @returns {WiseflowCustomValues}
+ * @returns {string} defaultShareType (default: ShareTypes.NONE)
+ * @returns {boolean} showShareType (default: true)
  */
 const getWiseflowCustomValues = () => {
   return {
     // Defaults
     defaultShareType: ShareTypes.NONE,
+    showShareType: true,
     ...JSON.parse(getCustomData())
   };
 };


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Add custom value that hides sharetype info to use in participant summary.

# What has changed?
Added `showShareType` value that defaults to true.
Hid borders and sharetype button if false.

# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/FEAT-5451
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->