### PR TITLE
feat-6470 Annotations on Safari remove focus hook fix

### DIFF
--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -86,6 +86,7 @@ function NotePopup(props) {
           {isEditable && (
             <DataElementWrapper
               type="button"
+              role="button"
               className="option note-popup-option"
               dataElement="notePopupEdit"
               onClick={onEditButtonClick}
@@ -96,6 +97,7 @@ function NotePopup(props) {
           {isDeletable && (
             <DataElementWrapper
               type="button"
+              role="button"
               className="option note-popup-option"
               dataElement="notePopupDelete"
               onClick={onDeleteButtonClick}

--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import useOnClickOutside from 'hooks/useOnClickOutside';
-import useOnFocusOutside from 'hooks/useOnFocusOutside';
 import DataElementWrapper from 'components/DataElementWrapper';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-
 import Icon from 'components/Icon';
+
 import './NotePopup.scss';
 
 const propTypes = {
@@ -38,10 +37,6 @@ function NotePopup(props) {
   const popupRef = React.useRef();
 
   useOnClickOutside(popupRef, () => {
-    closePopup();
-  });
-
-  useOnFocusOutside(popupRef, () => {
     closePopup();
   });
 
@@ -79,7 +74,7 @@ function NotePopup(props) {
         className={notePopupButtonClass}
         onClick={togglePopup}
         onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
+          if (e.key === 'Enter') {
             togglePopup(e);
           }
         }}
@@ -90,32 +85,20 @@ function NotePopup(props) {
         <div className={optionsClass}>
           {isEditable && (
             <DataElementWrapper
-              tabIndex={0}
               type="button"
-              role="button"
               className="option note-popup-option"
               dataElement="notePopupEdit"
               onClick={onEditButtonClick}
-              // Needed because safari otherwise loses focus on the button
-              // and the useOnFocusOutside hook triggers
-              onMouseDown={e => e.preventDefault()}
-              onMouseUp={e => e.preventDefault()}
             >
               {t('action.edit')}
             </DataElementWrapper>
           )}
           {isDeletable && (
             <DataElementWrapper
-              tabIndex={0}
               type="button"
-              role="button"
               className="option note-popup-option"
               dataElement="notePopupDelete"
               onClick={onDeleteButtonClick}
-              // Needed because safari otherwise loses focus on the button
-              // and the useOnFocusOutside hook triggers
-              onMouseDown={e => e.preventDefault()}
-              onMouseUp={e => e.preventDefault()}
             >
               {t('action.delete')}
             </DataElementWrapper>

--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -74,7 +74,7 @@ function NotePopup(props) {
         className={notePopupButtonClass}
         onClick={togglePopup}
         onKeyDown={e => {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' || e.key === ' ') {
             togglePopup(e);
           }
         }}


### PR DESCRIPTION
**Exact copy of #27, but with a different fix since the previous one did not work on test/stage and the bug is high priority!**
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/61479393/202423153-a9bb17b9-e3f1-4246-9f22-dbcbcaaa23b3.png">

# What is the purpose of this pull request?
Fix issue where on Safari the annotation edit/delete buttons would not work!
Copied the fix as they did it in `v8.10.0` https://github.com/PDFTron/webviewer-ui/blob/8.10/src/components/NotePopup/NotePopup.js

# What has changed?
Added prevent defaults on mousedown and mouseup events on the buttons!

Tested after the fix in:
Safari
Chrome
Firefox
## Jira links

```jira_links
https://uniwise.atlassian.net/browse/FEAT-6470
```
This is an exact copy of #27, but a different fix, since the previous one did not work on test/stage!

[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->