### PR TITLE
FEAT-6750 - Move full screen button and change more options icon

### DIFF
--- a/src/components/FullscreenButton/FullscreenButton.js
+++ b/src/components/FullscreenButton/FullscreenButton.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import ActionButton from 'components/ActionButton';
+import toggleFullscreen from 'helpers/toggleFullscreen';
+import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import selectors from 'selectors';
+
+export default function FullscreenButton() {
+  const [t] = useTranslation();
+  const isFullScreen = useSelector(selectors.isFullScreen);
+
+  return (
+    <ActionButton
+      dataElement="fullscreenButton"
+      className="row"
+      img={isFullScreen ? 'icon-header-full-screen-exit' : 'icon-header-full-screen'}
+      ariaLabel={isFullScreen ? t('action.exitFullscreen') : t('action.enterFullscreen')}
+      title={isFullScreen ? t('action.exitFullscreen') : t('action.enterFullscreen')}
+      role="option"
+      onClick={toggleFullscreen}
+    />
+  );
+}

--- a/src/components/FullscreenButton/index.js
+++ b/src/components/FullscreenButton/index.js
@@ -1,0 +1,3 @@
+import FullscreenButton from './FullscreenButton';
+
+export default FullscreenButton;

--- a/src/components/HeaderItems/HeaderItems.js
+++ b/src/components/HeaderItems/HeaderItems.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ToolButton from 'components/ToolButton';
+import FullscreenButton from 'components/FullscreenButton';
 import ToggleElementButton from 'components/ToggleElementButton';
 import ToolGroupButton from 'components/ToolGroupButton';
 import ActionButton from 'components/ActionButton';
@@ -45,6 +46,10 @@ class HeaderItems extends React.PureComponent {
         mediaQueryClassName += ' hide-in-mobile hide-in-small-mobile';
       }
       const key = `${type}-${dataElement || i}`;
+
+      if (dataElement === 'fullscreenButton') {
+        return <FullscreenButton />;
+      }
 
       switch (type) {
         case 'toolButton':


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Allow UI to add fullscreen button to header bar.

# What has changed?
Added FullscreenButton component
Allow addition to the header via "dataElement" prop.

# Notes for your reviewer
Connected to changes in https://github.com/UNIwise/assessment-frontend/pull/360

## Jira links
https://uniwise.atlassian.net/browse/FEAT-6750


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->