### PR TITLE
INCID-1266 - Clear timeout on tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -37,12 +37,17 @@ const Tooltip = forwardRef(({ content = '', translatedContent, children, hideSho
   useEffect(() => {
     const showToolTip = () => {
       timeoutRef.current = setTimeout(() => {
-        setShow(true);
+        if (timeoutRef.current) {
+          setShow(true);
+        }
       }, delayShow - opacityTimeout);
     };
 
     const hideTooltip = () => {
-      clearTimeout(timeoutRef.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
       setShow(false);
     };
 


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Fix error where tooltip spawned after selecting text tool from inline menu.

# What has changed?
Check if timeout is cleared.

# Notes for your reviewer
After merge, changes should be updated/merged in https://github.com/UNIwise/assessment-frontend/pull/405

## Jira links

```jira_links

```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->