### PR TITLE
QA-104 - Annotation menus overflowing

### DIFF
--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import useOnClickOutside from 'hooks/useOnClickOutside';
+import useOnFocusOutside from 'hooks/useOnFocusOutside';
+import useOverflowContainer from 'hooks/useOverflowContainer';
 import DataElementWrapper from 'components/DataElementWrapper';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
@@ -36,7 +38,13 @@ function NotePopup(props) {
   const [t] = useTranslation();
   const popupRef = React.useRef();
 
+  const { popupMenuRef, location } = useOverflowContainer('.normal-notes-container', 'bottom', isOpen);
+
   useOnClickOutside(popupRef, () => {
+    closePopup();
+  });
+
+  useOnFocusOutside(popupRef, () => {
     closePopup();
   });
 
@@ -82,7 +90,7 @@ function NotePopup(props) {
         <Icon glyph="icon-tools-more" />
       </div>
       {isOpen && (
-        <div className={optionsClass}>
+        <div className={`${optionsClass} ${location}`} ref={popupMenuRef}>
           {isEditable && (
             <DataElementWrapper
               type="button"

--- a/src/components/NotePopup/NotePopup.scss
+++ b/src/components/NotePopup/NotePopup.scss
@@ -7,8 +7,7 @@
   user-select: none;
   width: 28px;
   height: 28px;
-  right: -10px;
-  top: -8px;
+  position: relative;
 
   .overflow {
     width: 28px;
@@ -44,7 +43,14 @@
     }
     border-radius: 4px;
     background: var(--component-background);
-    top: 40px;
+
+    &.bottom {
+      top: calc(100% + 2px);
+    }
+
+    &.top {
+      bottom: calc(100% + 2px);
+    }
 
     .note-popup-option{
       @include button-reset;

--- a/src/components/NotePopup/NotePopupContainer.js
+++ b/src/components/NotePopup/NotePopupContainer.js
@@ -14,6 +14,7 @@ function NotePopupContainer(props) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [t] = useTranslation();
 
+
   React.useEffect(() => {
     function onUpdateAnnotationPermission() {
       setCanModify(core.canModify(annotation));

--- a/src/components/NoteState/NoteState.js
+++ b/src/components/NoteState/NoteState.js
@@ -43,11 +43,11 @@ function NoteState(props) {
   const isOwnedByCurrentUser = annotation.Author === core.getCurrentUser();
 
   useOnClickOutside(popupRef, () => {
-    // setIsOpen(false);
+    setIsOpen(false);
   });
 
   useOnFocusOutside(popupRef, () => {
-    // setIsOpen(false);
+    setIsOpen(false);
   });
 
   const togglePopup = e => {

--- a/src/components/NoteState/NoteState.js
+++ b/src/components/NoteState/NoteState.js
@@ -1,9 +1,10 @@
-import React, { useState, useRef } from 'react';
-import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import useOnClickOutside from 'hooks/useOnClickOutside';
 import useOnFocusOutside from 'hooks/useOnFocusOutside';
+import useOverflowContainer from 'hooks/useOverflowContainer';
+import PropTypes from 'prop-types';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import classNames from 'classnames';
 import Tooltip from '../Tooltip';
 
 import core from 'core';
@@ -37,15 +38,16 @@ function NoteState(props) {
   const [t] = useTranslation();
   const [isOpen, setIsOpen] = useState(openOnInitialLoad);
   const popupRef = useRef();
+  const { popupMenuRef, location } = useOverflowContainer('.normal-notes-container', 'bottom', isOpen);
 
   const isOwnedByCurrentUser = annotation.Author === core.getCurrentUser();
 
   useOnClickOutside(popupRef, () => {
-    setIsOpen(false);
+    // setIsOpen(false);
   });
 
   useOnFocusOutside(popupRef, () => {
-    setIsOpen(false);
+    // setIsOpen(false);
   });
 
   const togglePopup = e => {
@@ -111,7 +113,8 @@ function NoteState(props) {
         <div className={noteStateButtonClassName}>{icon}</div>
         {isOpen && (
           <div
-            className={`note-state-options ${isOwnedByCurrentUser ? 'enabled' : 'disabled'}`}
+            className={`note-state-options ${isOwnedByCurrentUser ? 'enabled' : 'disabled'} ${location}`}
+            ref={popupMenuRef}
             onKeyDown={e => {
               if (e.key === 'Escape') {
                 closeOptionsMenu();

--- a/src/components/NoteState/NoteState.scss
+++ b/src/components/NoteState/NoteState.scss
@@ -8,6 +8,7 @@
   user-select: none;
   margin-left: 15px;
   margin-right: 10px;
+  position: relative;
 
   @include ie11 { // for IE11 only
     padding-left: 0px;
@@ -41,7 +42,6 @@
 
   .note-state-options {
     @include button-reset;
-    top: 40px;
     font-size: inherit;
     display: flex;
     flex-direction: column;
@@ -51,6 +51,14 @@
     border-radius: 4px;
     background: var(--component-background);
 
+    &.bottom {
+      top: calc(100% + 2px);
+    }
+
+    &.top {
+      bottom: calc(100% + 2px);
+    }
+
     .note-state-option {
       display: flex;
       flex-direction: row;
@@ -58,6 +66,7 @@
       height: 35px;
       padding: 8px;
       border-radius: 0px;
+      white-space: nowrap;
 
       .Icon, .share-type-icon {
         margin-right: 5px;

--- a/src/hooks/useOverflowContainer.js
+++ b/src/hooks/useOverflowContainer.js
@@ -1,0 +1,38 @@
+import { useState, useRef, useLayoutEffect } from 'react';
+
+/**
+ * Check if popup overflows top or bottom of container and return new location
+ * @param {string} containerElementSelector
+ * @param {'bottom' | 'top'} defaultLocation
+ * @param {boolean} isOpen
+ * @returns {{popupMenuRef: React.MutableRefObject<null>, location: 'bottom' | 'top'}}
+ * 
+ */
+const useOverflowContainer = (containerElementSelector, defaultLocation, isOpen) => {
+  const [location, setLocation] = useState(defaultLocation);
+  const popupMenuRef = useRef();
+
+  useLayoutEffect(() => {
+    const popupMenuEle = popupMenuRef.current;
+    const containerEle = document.querySelector(containerElementSelector);
+
+    if (isOpen && popupMenuEle && containerEle) {
+      const popupRect = popupMenuEle.getBoundingClientRect();
+      const containerRect = containerEle.getBoundingClientRect();
+
+      const shouldRelocateTop = location === 'bottom' && popupRect.bottom > containerRect.bottom;
+      if (shouldRelocateTop) {
+        setLocation('top');
+      }
+
+      const shouldRelocateBottom = location === 'top' && popupRect.top < containerRect.top;
+      if (shouldRelocateBottom) {
+        setLocation('bottom');
+      }
+    }
+  }, [isOpen, popupMenuRef, location, containerElementSelector]);
+
+  return { popupMenuRef, location };
+};
+
+export default useOverflowContainer;


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Fix overflowing bottom menus for note panel.

# What has changed?
Added hook to detect overflow
Fixed overflow for note sharetype state and note popup

# Notes for your reviewer

## Jira links
https://uniwise.atlassian.net/browse/QA-104
```jira_links

```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->