### PR TITLE
FEAT-7834 - add dots icon instead of cog on the topbar

### DIFF
--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -111,7 +111,7 @@ export default {
           },
           hidden: ['small-mobile']
         },
-        { type: 'toggleElementButton', dataElement: 'menuButton', element: 'menuOverlay', img: 'icon-header-settings-line', title: 'component.menuOverlay', hidden: ['small-mobile'] },
+        { type: 'toggleElementButton', dataElement: 'menuButton', element: 'menuOverlay', img: 'icon-tool-more', title: 'component.menuOverlay', hidden: ['small-mobile'] },
         {
           type: 'actionButton',
           dataElement: 'moreButton',
@@ -127,7 +127,7 @@ export default {
       'small-mobile-more-buttons': [
         { type: 'toggleElementButton', dataElement: 'searchButton', element: 'searchPanel', img: 'icon-header-search', title: 'component.searchPanel' },
         { type: 'toggleElementButton', dataElement: 'toggleNotesButton', element: 'notesPanel', img: 'icon-header-chat-line', title: 'component.notesPanel' },
-        { type: 'toggleElementButton', dataElement: 'menuButton', element: 'menuOverlay', img: 'icon-header-settings-line', title: 'component.menuOverlay' },
+        { type: 'toggleElementButton', dataElement: 'menuButton', element: 'menuOverlay', img: 'icon-tool-more', title: 'component.menuOverlay' },
         { type: 'spacer' },
         {
           type: 'actionButton',


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Changes out the cog icon for the settings menu on the topbar for a three dots icon.

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/61479393/234795663-694f1258-1b6c-4c78-b33c-e83c8713cdd4.png">

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/FEAT-7834
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->