### PR TITLE
QA-260 - Multi select button works as a default option while marking

### DIFF
--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -96,6 +96,7 @@ const NotesPanel = ({ currentLeftPanelWidth }) => {
       setNotes([]);
       setSelectedNoteIds({});
       setSearchInput('');
+      setMultiSelectMode(false);
     };
     core.addEventListener('documentUnloaded', onDocumentUnloaded);
     return () => core.removeEventListener('documentUnloaded', onDocumentUnloaded);
@@ -176,7 +177,7 @@ const NotesPanel = ({ currentLeftPanelWidth }) => {
     const content = note.getContents();
     const authorName = core.getDisplayAuthor(note['Author']);
     const annotationPreview = note.getCustomData('trn-annot-preview');
-    
+
     /** CUSTOM WISEFLOW */
     const reference = getAnnotationReference(note);
 
@@ -243,7 +244,7 @@ const NotesPanel = ({ currentLeftPanelWidth }) => {
 
   // debounced callback to fire unpostedAnnotationsChanged event
   const onUnpostedAnnotationChanged = useCallback(
-    debounce(pendingEditTextMap => {
+    debounce((pendingEditTextMap) => {
       const unpostedAnnotationsCount = Object.values(pendingEditTextMap).reduce((count, pendingText) => {
         if (pendingText !== undefined) {
           return count + 1;


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [x] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Fixes an issue where multiselected annotations menu would reopen when changing participants in the `assessment-frontend`
 
# What has changed?
Disabled the `multiSelectMode` inside of the `NotesPanel` when the document gets unloaded
# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/QA-260
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->