### PR TITLE
Hotfix/incid 2336 annotations filter text is overlapped

### DIFF
--- a/i18n/translation-en.json
+++ b/i18n/translation-en.json
@@ -519,7 +519,9 @@
       "type": "Type",
       "shareType": "Share type",
       "coAssessor": "Co-assessor",
-      "author": "Author"
+      "author": "Author",
+      "filterDocument": "Filter document and comments panel",
+      "filterSettings": "Filter Settings"
     },
     "state": {
       "accepted": "Accepted",
@@ -921,38 +923,9 @@
       "November",
       "December"
     ],
-    "monthsShort": [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sept",
-      "Oct",
-      "Nov",
-      "Dec"
-    ],
-    "weekdays": [
-      "Sunday",
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday"
-    ],
-    "weekdaysShort": [
-      "Sun",
-      "Mon",
-      "Tue",
-      "Wed",
-      "Thu",
-      "Fri",
-      "Sat"
-    ],
+    "monthsShort": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"],
+    "weekdays": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    "weekdaysShort": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
     "today": "Today",
     "invalidDateTime": "Invalid Date/Time: Input should match format"
   },

--- a/src/components/Choice/Choice.scss
+++ b/src/components/Choice/Choice.scss
@@ -12,6 +12,7 @@
 
 .ui__choice__label {
   font-size: 13px !important;
+  overflow: hidden  ;
 }
 
 .ui__choice__input--switch {

--- a/src/components/FilterAnnotModal/FilterAnnotModal.js
+++ b/src/components/FilterAnnotModal/FilterAnnotModal.js
@@ -389,7 +389,6 @@ const FilterAnnotModal = () => {
                     backgroundColor: `${ShareTypeColors[val]}`,
                     padding: '5px 10px',
                     borderRadius: '5px',
-                    color: '#fff',
                   }}
                 >
                   {t(`option.state.${val.toLocaleLowerCase()}`)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,9 +6027,9 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-"extract-zip@git+https://github.com/lbittner-pdftron/extract-zip.git":
+"extract-zip@https://github.com/lbittner-pdftron/extract-zip.git":
   version "1.6.7"
-  resolved "git+https://github.com/lbittner-pdftron/extract-zip.git#011ceb901187b90887eac0ee24ef6a8a0cd1b6a9"
+  resolved "https://github.com/lbittner-pdftron/extract-zip.git#011ceb901187b90887eac0ee24ef6a8a0cd1b6a9"
   dependencies:
     concat-stream "1.6.2"
     debug "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,9 +6027,9 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-"extract-zip@https://github.com/lbittner-pdftron/extract-zip.git":
+"extract-zip@git+https://github.com/lbittner-pdftron/extract-zip.git":
   version "1.6.7"
-  resolved "https://github.com/lbittner-pdftron/extract-zip.git#011ceb901187b90887eac0ee24ef6a8a0cd1b6a9"
+  resolved "git+https://github.com/lbittner-pdftron/extract-zip.git#011ceb901187b90887eac0ee24ef6a8a0cd1b6a9"
   dependencies:
     concat-stream "1.6.2"
     debug "2.6.9"


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
* Assessor: Annotations filter text is overlapped
* Missing translations: 'Filter' modal for annotations within the New Marking Tool


# What has changed?
I have fixed the overlapping filter text and added the missing translations.

# Notes for your reviewer

## Jira links

> - [INCID-2336]



[INCID-2336]: https://uniwise.atlassian.net/browse/INCID-2336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ