### PR TITLE
added select all button next to multiselect button

### DIFF
--- a/src/components/NotesPanelHeader/NotesPanelHeader.js
+++ b/src/components/NotesPanelHeader/NotesPanelHeader.js
@@ -48,6 +48,7 @@ function NotesPanelHeader({
     isOfficeEditorMode,
     officeEditorEditMode,
     customizableUI,
+    activeDocumentViewerKey,
   ] = useSelector(
     (state) => [
       selectors.getSortStrategy(state),
@@ -57,6 +58,7 @@ function NotesPanelHeader({
       selectors.getIsOfficeEditorMode(state),
       selectors.getOfficeEditorEditMode(state),
       selectors.getFeatureFlags(state)?.customizableUI,
+      selectors.getActiveDocumentViewerKey(state),
     ],
     shallowEqual
   );
@@ -175,19 +177,52 @@ function NotesPanelHeader({
           className="buttons-container"
         >
           {isMultiSelectEnabled && !isOfficeEditorMode && (
-            <Button
-              dataElement={DataElements.NOTE_MULTI_SELECT_MODE_BUTTON}
-              className={classNames({
-                active: isMultiSelectMode,
-              })}
-              disabled={notes.length === 0}
-              img="icon-annotation-select-multiple"
-              onClick={() => {
-                core.deselectAllAnnotations();
-                toggleMultiSelectMode();
-              }}
-              title={t('component.multiSelectButton')}
-            />
+            <>
+              {isMultiSelectMode && (
+                <Button
+                  dataElement={DataElements.NOTE_SELECT_ALL_BUTTON}
+                  disabled={notes.length === 0}
+                  img="icon-header-chat-line"
+                  onClick={() => {
+                    const selectedAnnotations = core.getSelectedAnnotations(activeDocumentViewerKey);
+                    if(selectedAnnotations.length > 0) {
+                      core.deselectAllAnnotations();
+                    } else {
+                      core.selectAnnotations(notes, activeDocumentViewerKey);
+                    } 
+                  }}
+                  className={classNames({
+                    'inactive': notes.length === 0,
+                    'select-all-button': true,
+                    active: core.getSelectedAnnotations(activeDocumentViewerKey).length === notes.length,
+                  })}
+                  style={{ 
+                    display: 'flex', 
+                    alignItems: 'center', 
+                    flexDirection: 'row',
+                    justifyContent: 'center',
+                    width: '38px',
+                    gap: '3px'
+                  }}
+                  label={t('option.print.all')}
+                  title={t('action.selectAll')}
+                />
+              )}
+              
+              <Button
+                dataElement={DataElements.NOTE_MULTI_SELECT_MODE_BUTTON}
+                className={classNames({
+                  active: isMultiSelectMode,
+                })}
+                disabled={notes.length === 0}
+                img="icon-annotation-select-multiple"
+                onClick={() => {
+                  core.deselectAllAnnotations();
+                  toggleMultiSelectMode();
+                }}
+                title={t('component.multiSelectButton')}
+              />
+            </>
           )}
           <Button
             dataElement={DataElements.NotesPanel.DefaultHeader.FILTER_ANNOTATION_BUTTON}

--- a/src/components/NotesPanelHeader/NotesPanelHeader.scss
+++ b/src/components/NotesPanelHeader/NotesPanelHeader.scss
@@ -171,3 +171,10 @@
     height: 16px;
   }
 }
+
+.select-all-button {
+  .Icon {
+    width: 16px !important;
+    height: 16px !important;
+  }
+}

--- a/src/constants/dataElement.js
+++ b/src/constants/dataElement.js
@@ -185,6 +185,7 @@ const DataElements = {
 
   // Notes panel - multi select
   NOTE_MULTI_SELECT_MODE_BUTTON: 'multiSelectModeButton',
+  NOTE_SELECT_ALL_BUTTON: 'selectAllAnnotationsButton',
   NOTE_MULTI_REPLY_BUTTON: 'multiReplyButton',
   NOTE_MULTI_STATE_BUTTON: 'multiStateButton',
   NOTE_MULTI_SHARE_TYPE_BUTTON: 'multiShareTypeButton',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,9 +6027,9 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-"extract-zip@git+https://github.com/lbittner-pdftron/extract-zip.git":
+"extract-zip@https://github.com/lbittner-pdftron/extract-zip.git":
   version "1.6.7"
-  resolved "git+https://github.com/lbittner-pdftron/extract-zip.git#011ceb901187b90887eac0ee24ef6a8a0cd1b6a9"
+  resolved "https://github.com/lbittner-pdftron/extract-zip.git#011ceb901187b90887eac0ee24ef6a8a0cd1b6a9"
   dependencies:
     concat-stream "1.6.2"
     debug "2.6.9"


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Add a "Select all" option next to the multiselect button in pdftron.

# What has changed?
I have implemented a button next to the multiselect button, so when multiselect is active, it is possible to select all annotations using the new “Select All” button

# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/MT-120

```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->