### PR TITLE
fix(MT-925): Refactor isContentEditable logic in NotesPanel

### DIFF
--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -289,7 +289,7 @@ const NotesPanel = ({
       searchInput,
       resize,
       isSelected: selectedNoteIds[currNote.Id],
-      isContentEditable: core.canModifyContents(currNote, activeDocumentViewerKey) && !currNote.getContents(),
+      isContentEditable: core.canModifyContents(currNote, activeDocumentViewerKey),
       pendingEditTextMap,
       setPendingEditText,
       pendingReplyMap,


### PR DESCRIPTION
# What is the purpose of this pull request?
Fix an issue in PDFTron where, during the first edit of a text annotation, the text box loses focus

# What has changed?
Adjusted the annotation editing logic to maintain the text box focus

# Notes for your reviewer
This specifically addresses the first-time edit behavior

## Jira links

https://uniwise.atlassian.net/browse/MT-925

[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)