### PR TITLE
feat(RC-4): added implementation for copy annotations

### DIFF
--- a/src/components/FileAttachmentPanel/FileAttachmentPanel.js
+++ b/src/components/FileAttachmentPanel/FileAttachmentPanel.js
@@ -46,14 +46,20 @@ const FileAttachmentPanel = ({ initialFiles = initialFilesDefault }) => {
   const [showFileIdProcessSpinner, setFileIdProcessSpinner] = useState(null);
 
   useEffect(() => {
+    let isMounted = true;
     const updateFileAttachments = async () => {
       const attachments = await getFileAttachments();
-      setFileAttachments(attachments);
+      if (isMounted) {
+        setFileAttachments(attachments);
+      }
     };
+
     core.addEventListener('annotationChanged', updateFileAttachments);
     core.addEventListener('documentLoaded', updateFileAttachments);
     updateFileAttachments();
+
     return () => {
+      isMounted = false;
       core.removeEventListener('annotationChanged', updateFileAttachments);
       core.removeEventListener('documentLoaded', updateFileAttachments);
     };

--- a/src/components/FileAttachmentPanel/FileAttachmentPanel.js
+++ b/src/components/FileAttachmentPanel/FileAttachmentPanel.js
@@ -46,20 +46,14 @@ const FileAttachmentPanel = ({ initialFiles = initialFilesDefault }) => {
   const [showFileIdProcessSpinner, setFileIdProcessSpinner] = useState(null);
 
   useEffect(() => {
-    let isMounted = true;
     const updateFileAttachments = async () => {
       const attachments = await getFileAttachments();
-      if (isMounted) {
-        setFileAttachments(attachments);
-      }
+      setFileAttachments(attachments);
     };
-
     core.addEventListener('annotationChanged', updateFileAttachments);
     core.addEventListener('documentLoaded', updateFileAttachments);
     updateFileAttachments();
-
     return () => {
-      isMounted = false;
       core.removeEventListener('annotationChanged', updateFileAttachments);
       core.removeEventListener('documentLoaded', updateFileAttachments);
     };

--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -292,7 +292,12 @@ const NoteContent = ({
     if (!isGroupMember) {
       if (isReply) {
         onReplyClicked(annotation);
-      } else if (!isEditing) {
+      } else if (isEditing) {
+        // already editing, do nothing
+      } else if (isSelected && setIsEditing && core.canModifyContents(annotation)) {
+        // if already selected, enter edit mode on click
+        setIsEditing(true, noteIndex);
+      } else {
         // collapse expanded note when top noteContent is clicked if it's not being edited
         onTopNoteContentClicked();
       }

--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -22,6 +22,7 @@ const propTypes = {
   openPopup: PropTypes.func,
   isEditable: PropTypes.bool,
   isDeletable: PropTypes.bool,
+  isCopyable: PropTypes.bool,
   isOpen: PropTypes.bool,
   isReply: PropTypes.bool,
 };
@@ -37,6 +38,7 @@ function NotePopup(props) {
     openPopup = noop,
     isEditable,
     isDeletable,
+    isCopyable,
     isOpen,
     isReply,
   } = props;
@@ -81,7 +83,7 @@ function NotePopup(props) {
     handleCopy();
   }
 
-  if (!isEditable && !isDeletable) {
+  if (!isEditable && !isDeletable && !isCopyable) {
     return null;
   }
 
@@ -118,7 +120,7 @@ function NotePopup(props) {
               {t('action.edit')}
             </DataElementWrapper>
           )}
-          {isEditable && (
+          {isCopyable && (
             <DataElementWrapper
               tabIndex={0}
               type="button"

--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -17,6 +17,7 @@ import { useSelector } from 'react-redux';
 const propTypes = {
   handleEdit: PropTypes.func,
   handleDelete: PropTypes.func,
+  handleCopy: PropTypes.func,
   closePopup: PropTypes.func,
   openPopup: PropTypes.func,
   isEditable: PropTypes.bool,
@@ -31,6 +32,7 @@ function NotePopup(props) {
   const {
     handleEdit = noop,
     handleDelete = noop,
+    handleCopy = noop,
     closePopup = noop,
     openPopup = noop,
     isEditable,
@@ -73,6 +75,12 @@ function NotePopup(props) {
     handleDelete();
   }
 
+  function onCopyButtonClick(e) {
+    e.stopPropagation();
+    closePopup();
+    handleCopy();
+  }
+
   if (!isEditable && !isDeletable) {
     return null;
   }
@@ -108,6 +116,20 @@ function NotePopup(props) {
               onMouseUp={e => e.preventDefault()}
             >
               {t('action.edit')}
+            </DataElementWrapper>
+          )}
+          {isEditable && (
+            <DataElementWrapper
+              tabIndex={0}
+              type="button"
+              role="button"
+              className="option note-popup-option"
+              dataElement="notePopupCopy"
+              onClick={onCopyButtonClick}
+              onMouseDown={e => e.preventDefault()}
+              onMouseUp={e => e.preventDefault()}
+            >
+              {t('action.copy')}
             </DataElementWrapper>
           )}
           {isDeletable && (

--- a/src/components/NotePopup/NotePopup.spec.js
+++ b/src/components/NotePopup/NotePopup.spec.js
@@ -242,10 +242,10 @@ describe('NotePopup', () => {
     expect(closePopup).toHaveBeenCalled();
   });
 
-  it('Should not render component when not editable and not deletable', () => {
+  it('Should not render component when not editable and not deletable and not copyable', () => {
     const { container } = render(
       <Provider store={store}>
-        <NotePopup isOpen isEditable={false} isDeletable={false} />
+        <NotePopup isOpen isEditable={false} isDeletable={false} isCopyable={false} />
       </Provider>,
     );
     expect(container.querySelector('.NotePopup')).not.toBeInTheDocument();
@@ -261,6 +261,7 @@ describe('NotePopupContainer', () => {
         viewer: {
           activeDocumentViewerKey: 1,
           disabledElements: {},
+          customElementOverrides: {},
         },
       }),
     );

--- a/src/components/NotePopup/NotePopupContainer.js
+++ b/src/components/NotePopup/NotePopupContainer.js
@@ -66,7 +66,7 @@ function NotePopupContainer(props) {
 
   const isEditable = canModifyContents;
   const isDeletable = canModify && !annotation?.NoDelete;
-  const isCopyable = canModify;
+  const isCopyable = true;
 
   const passProps = {
     handleEdit,

--- a/src/components/NotePopup/NotePopupContainer.js
+++ b/src/components/NotePopup/NotePopupContainer.js
@@ -43,6 +43,24 @@ function NotePopupContainer(props) {
     core.deleteAnnotations([annotation, ...annotation.getGroupedChildren()], undefined, activeDocumentViewerKey);
   }, [annotation]);
 
+  const handleCopy = React.useCallback(() => {
+    const annotManager = core.getAnnotationManager(activeDocumentViewerKey);
+    annotManager.deselectAllAnnotations();
+    const copiedAnnotation = annotManager.getAnnotationCopy(annotation);
+    if (Array.isArray(copiedAnnotation)) {
+      copiedAnnotation.forEach((copiedAnnot) => {
+        annotManager.addAnnotation(copiedAnnot);
+        annotManager.redrawAnnotation(copiedAnnot);
+      });
+    } else if (copiedAnnotation) {
+      annotManager.addAnnotation(copiedAnnotation);
+      annotManager.redrawAnnotation(copiedAnnotation);
+    }
+    window.dispatchEvent(new CustomEvent('annotationCopied', {
+      detail: { annotation, copiedAnnotation }
+    }));
+  }, [annotation, activeDocumentViewerKey]);
+
   const openPopup = () => setIsOpen(true);
   const closePopup = () => setIsOpen(false);
 
@@ -52,6 +70,7 @@ function NotePopupContainer(props) {
   const passProps = {
     handleEdit,
     handleDelete,
+    handleCopy,
     isEditable,
     isDeletable,
     isOpen,

--- a/src/components/NotePopup/NotePopupContainer.js
+++ b/src/components/NotePopup/NotePopupContainer.js
@@ -66,6 +66,7 @@ function NotePopupContainer(props) {
 
   const isEditable = canModifyContents;
   const isDeletable = canModify && !annotation?.NoDelete;
+  const isCopyable = canModify;
 
   const passProps = {
     handleEdit,
@@ -73,6 +74,7 @@ function NotePopupContainer(props) {
     handleCopy,
     isEditable,
     isDeletable,
+    isCopyable,
     isOpen,
     closePopup,
     openPopup,


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
As a reviewer, I want to copy assessor annotations into my own feedback and edit them, so that I can reuse assessor input while tailoring annotations before sharing feedback.

# What has changed?

# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/RC-4
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->