### PR TITLE
feat(RC-34): copy button only appears on original annotations

### DIFF
--- a/src/components/NotePopup/NotePopupContainer.js
+++ b/src/components/NotePopup/NotePopupContainer.js
@@ -4,6 +4,8 @@ import NotePopup from './NotePopup';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import selectors from 'selectors';
+import { setAnnotationShareType } from 'helpers/annotationShareType';
+import ShareTypes from 'constants/shareTypes';
 
 function NotePopupContainer(props) {
   const [
@@ -45,14 +47,22 @@ function NotePopupContainer(props) {
 
   const handleCopy = React.useCallback(() => {
     const annotManager = core.getAnnotationManager(activeDocumentViewerKey);
+    const currentUser = core.getCurrentUser(activeDocumentViewerKey);
     annotManager.deselectAllAnnotations();
     const copiedAnnotation = annotManager.getAnnotationCopy(annotation);
+    const applyPrivateDefaults = (annot) => {
+      setAnnotationShareType(annot, ShareTypes.NONE);
+      annot.Author = currentUser;
+      annot.setCustomData('isCopy', 'true');
+    };
     if (Array.isArray(copiedAnnotation)) {
       copiedAnnotation.forEach((copiedAnnot) => {
+        applyPrivateDefaults(copiedAnnot);
         annotManager.addAnnotation(copiedAnnot);
         annotManager.redrawAnnotation(copiedAnnot);
       });
     } else if (copiedAnnotation) {
+      applyPrivateDefaults(copiedAnnotation);
       annotManager.addAnnotation(copiedAnnotation);
       annotManager.redrawAnnotation(copiedAnnotation);
     }
@@ -66,7 +76,7 @@ function NotePopupContainer(props) {
 
   const isEditable = canModifyContents;
   const isDeletable = canModify && !annotation?.NoDelete;
-  const isCopyable = true;
+  const isCopyable = annotation?.getCustomData('isCopy') !== 'true';
 
   const passProps = {
     handleEdit,


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

# What has changed?

# Notes for your reviewer

## Jira links

```jira_links

```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->