### PR TITLE
fix(FEAT-11061): handle empty items in CommentTextarea rendering

### DIFF
--- a/src/components/NoteTextarea/CommentTextarea/CommentTextarea.js
+++ b/src/components/NoteTextarea/CommentTextarea/CommentTextarea.js
@@ -146,7 +146,11 @@ const CommentTextarea = React.forwardRef(
         contentArray.pop();
         value = contentArray.map((item) => {
           const paragraph = document.createElement('p');
-          paragraph.innerText = item || '<br>';
+          if (item) {
+            paragraph.innerText = item;
+          } else {
+            paragraph.innerHTML = '<br>';
+          }
           return paragraph.outerHTML;
         }
         ).join('');


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Fix a bug where adding an empty line to an annotation, saving it, and then re-editing it would display literal <br> tags instead of empty lines.

# What has changed?
The fix separates the two cases:

1. Non-empty lines
2. Empty lines

# Notes for your reviewer

## Jira links
https://uniwise.atlassian.net/browse/FEAT-11061

[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->