### PR TITLE
fix(RC-43): conditional option rendering in NotePopup

### DIFF
--- a/src/components/NotePopup/NotePopup.js
+++ b/src/components/NotePopup/NotePopup.js
@@ -46,6 +46,13 @@ function NotePopup(props) {
   const [t] = useTranslation();
   const popupRef = React.useRef();
   const customizableUI = useSelector(state => selectors.getFeatureFlags(state)?.customizableUI);
+  const isEditDisabled = useSelector(state => selectors.isElementDisabled(state, 'notePopupEdit'));
+  const isCopyDisabled = useSelector(state => selectors.isElementDisabled(state, 'notePopupCopy'));
+  const isDeleteDisabled = useSelector(state => selectors.isElementDisabled(state, 'notePopupDelete'));
+
+  const hasEditOption = isEditable && !isEditDisabled;
+  const hasCopyOption = isCopyable && !isCopyDisabled;
+  const hasDeleteOption = isDeletable && !isDeleteDisabled;
 
   const { popupMenuRef, location } = useOverflowContainer(isOpen, { container: '.normal-notes-container' });
 
@@ -83,7 +90,7 @@ function NotePopup(props) {
     handleCopy();
   }
 
-  if (!isEditable && !isDeletable && !isCopyable) {
+  if (!hasEditOption && !hasCopyOption && !hasDeleteOption) {
     return null;
   }
 
@@ -104,7 +111,7 @@ function NotePopup(props) {
       />
       {isOpen && (
         <div className={`${optionsClass} ${location}`} ref={popupMenuRef}>
-          {isEditable && (
+          {hasEditOption && (
             <DataElementWrapper
               tabIndex={0}
               type="button"
@@ -120,7 +127,7 @@ function NotePopup(props) {
               {t('action.edit')}
             </DataElementWrapper>
           )}
-          {isCopyable && (
+          {hasCopyOption && (
             <DataElementWrapper
               tabIndex={0}
               type="button"
@@ -134,7 +141,7 @@ function NotePopup(props) {
               {t('action.copy')}
             </DataElementWrapper>
           )}
-          {isDeletable && (
+          {hasDeleteOption && (
             <DataElementWrapper
               tabIndex={0}
               type="button"


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

# What has changed?

# Notes for your reviewer

## Jira links

```jira_links

```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->