### PR TITLE
fix(FEAT-11159): fixed Annotation does not trigger autosave callback …

### DIFF
--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
@@ -555,6 +555,31 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
     return () => debouncedSetContents.flush();
   }, [debouncedSetContents]);
 
+  // Always keep a ref to the latest setContents so the unmount cleanup can call it
+  const setContentsRef = useRef(setContents);
+  useLayoutEffect(() => {
+    setContentsRef.current = setContents;
+  });
+
+  // Track whether the user has made unsaved edits — used by the unmount cleanup
+  // to avoid triggering annotationChanged (and SET_CAN_UNDO/SET_CAN_REDO) on scroll
+  const hasUnsavedEditsRef = useRef(false);
+
+  // Save annotation when ContentArea unmounts (panel closed, annotation deselected, etc.).
+  // handleBlur cannot fire here because the component unmounts before the browser dispatches
+  // the blur event (mousedown on PDF → Redux deselect → unmount → blur never fires).
+  // useLayoutEffect cleanup runs synchronously before DOM removal, so textareaRef is still valid.
+  // Only saves if the user actually typed something to avoid spurious undo/redo history entries.
+  useLayoutEffect(() => {
+    return () => {
+      if (textareaRef.current && hasUnsavedEditsRef.current) {
+        console.log('ContentArea unmounting with unsaved edits — saving annotation');
+        debouncedSetContents.flush();
+        setContentsRef.current({ preventDefault: () => {}, type: 'blur' });
+      }
+    };
+  }, []);
+
   useEffect(() => {
     // on initial mount, focus the last character of the textarea
     if (isAnyCustomPanelOpen || ((isNotesPanelOpen || isInlineCommentOpen) && textareaRef.current)) {
@@ -666,6 +691,8 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
       core.drawAnnotationsFromList([annotation]);
     }
 
+    hasUnsavedEditsRef.current = false;
+
     if (e && e.type === 'blur') {
       if (textAreaValue !== '') {
         onTextAreaValueChange(undefined, annotation.Id);
@@ -675,6 +702,7 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
   };
 
   const handleBlur = (e) => {
+    console.log('handleBlur called with event:', e);
     debouncedSetContents.flush();
 
     setCurAnnotId(undefined);
@@ -699,6 +727,7 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
   const handleChange = (value) => {
     onTextAreaValueChange(value, annotation.Id);
     setSavedState(AnnotationSavedState.UNSAVED_EDITS);
+    hasUnsavedEditsRef.current = true;
 
     try {
       const storageKey = `annotation_draft_${annotation.Id}`;

--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -561,19 +561,11 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
     setContentsRef.current = setContents;
   });
 
-  // Track whether the user has made unsaved edits — used by the unmount cleanup
-  // to avoid triggering annotationChanged (and SET_CAN_UNDO/SET_CAN_REDO) on scroll
   const hasUnsavedEditsRef = useRef(false);
 
-  // Save annotation when ContentArea unmounts (panel closed, annotation deselected, etc.).
-  // handleBlur cannot fire here because the component unmounts before the browser dispatches
-  // the blur event (mousedown on PDF → Redux deselect → unmount → blur never fires).
-  // useLayoutEffect cleanup runs synchronously before DOM removal, so textareaRef is still valid.
-  // Only saves if the user actually typed something to avoid spurious undo/redo history entries.
   useLayoutEffect(() => {
     return () => {
       if (textareaRef.current && hasUnsavedEditsRef.current) {
-        console.log('ContentArea unmounting with unsaved edits — saving annotation');
         debouncedSetContents.flush();
         setContentsRef.current({ preventDefault: () => {}, type: 'blur' });
       }
@@ -702,7 +694,6 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
   };
 
   const handleBlur = (e) => {
-    console.log('handleBlur called with event:', e);
     debouncedSetContents.flush();
 
     setCurAnnotId(undefined);


### PR DESCRIPTION
…when clicking outside the annotations sidebar

<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Annotation does not trigger autosave callback when clicking outside the annotations sidebar

# What has changed?

# Notes for your reviewer

## Jira links

```jira_links
FEAT-11159
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->