### PR TITLE
fix(INCID-2886): disable share type button for non-owned annotations

### DIFF
--- a/src/components/NoteShareType/NoteShareType.js
+++ b/src/components/NoteShareType/NoteShareType.js
@@ -90,7 +90,7 @@ function NoteShareType(props) {
       }}
       ref={wrapperRef}
     >
-      <button className="share-type-icon-button" onMouseDown={preventEditorBlur} onClick={togglePopup}>
+      <button className="share-type-icon-button" onMouseDown={preventEditorBlur} onClick={togglePopup} disabled={!isOwnedByCurrentUser}>
         <ShareTypeIcon shareType={shareType} label={annotationTooltip} />
       </button>
 


### PR DESCRIPTION
## Summary
- Assessor 2 was able to click the share type button on annotations authored by Assessor 1 and change the sharing level, which is not permitted
- `isOwnedByCurrentUser` was already computed (`annotation.Author === core.getCurrentUser()`) and passed to the outer `DataElementWrapper` as `disabled` — but `DataElementWrapper` renders as a `div`, so that attribute had no effect on child button clicks
- Added `disabled={!isOwnedByCurrentUser}` directly to the inner `<button>`, which prevents interaction and applies the existing disabled CSS styling

## Test plan
- [ ] Login as Assessor 1, add an annotation, set sharing level to "Co-assessor"
- [ ] Login as Assessor 2, open the same annotation — verify the share type icon is visible but the button is non-interactive (cursor: default, no dropdown opens)
- [ ] Login as Assessor 1, verify you can still change the share type on your own annotation

Fixes: INCID-2886

🤖 Generated with [Claude Code](https://claude.com/claude-code)