### PR TITLE
hotfix(INCID-2886): disable share type button for non-owned annotations

### DIFF
--- a/src/components/NoteShareType/NoteShareType.js
+++ b/src/components/NoteShareType/NoteShareType.js
@@ -90,7 +90,7 @@ function NoteShareType(props) {
       }}
       ref={wrapperRef}
     >
-      <button className="share-type-icon-button" onMouseDown={preventEditorBlur} onClick={togglePopup}>
+      <button className="share-type-icon-button" onMouseDown={preventEditorBlur} onClick={togglePopup} disabled={!isOwnedByCurrentUser}>
         <ShareTypeIcon shareType={shareType} label={annotationTooltip} />
       </button>
 


### PR DESCRIPTION
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

Prevent assessors from changing the sharing level of annotations they do not own. Assessor 2 was able to click the share type button on Assessor 1's annotations and change the sharing level.

# What has changed?

`NoteShareType.js`: added `disabled={!isOwnedByCurrentUser}` to the inner `<button>`. The `isOwnedByCurrentUser` flag (`annotation.Author === core.getCurrentUser()`) was already computed and passed to the outer `DataElementWrapper`, but that wrapper renders as a `div` so the attribute had no effect on child button clicks. Disabling the button directly prevents interaction for non-owners and applies the existing disabled CSS styling.

# Notes for your reviewer

No visual change for annotation owners. Non-owners see the share type icon (read-only) but cannot open the dialog.

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/INCID-2886
```