### PR TITLE
fix: guard window.Core?.setBasePath call to prevent crash when not a function

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -280,7 +280,9 @@ const App = ({ removeEventHandlers, initialDirection }) => {
       const isMultiDoc = initialDoc.length > 1;
       const startOffline = getHashParameters('startOffline', false);
       const basePath = getHashParameters('basePath', '');
-      window.Core.setBasePath(basePath);
+      if (typeof window.Core?.setBasePath === 'function') {
+        window.Core.setBasePath(basePath);
+      }
 
       if (isMultiDoc && !isMultiTabAlreadyEnabled) {
         prepareMultiTab(initialDoc, store);


### PR DESCRIPTION
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

Guard the `window.Core?.setBasePath` call in `App.js` to prevent a runtime crash when `setBasePath` is not available as a function (e.g. when the PDF core is in a degraded state such as an expired AMS license).

# What has changed?

- `src/components/App/App.js`: Wrapped `window.Core.setBasePath(basePath)` with a `typeof` check so it only executes when the function exists, preventing an uncaught `TypeError` that blocked viewer initialisation.

# Notes for your reviewer

The crash occurred because `window.Core.setBasePath` is `undefined` when the PDF worker fails to initialise (e.g. AMS licence expiry). Without this guard the entire viewer throws before rendering.

## Jira links

```jira_links

```