### PR TITLE
fix: guard window.Core?.Tools?.ToolNames access to prevent crash when Core is not initialised

### DIFF
--- a/src/helpers/getToolStyles.js
+++ b/src/helpers/getToolStyles.js
@@ -2,7 +2,10 @@ import core from 'core';
 
 export default (toolName) => {
   const tool = core.getTool(toolName);
-  const ToolNames = window.Core.Tools.ToolNames;
+  const ToolNames = window.Core?.Tools?.ToolNames;
+  if (!ToolNames) {
+    return tool?.defaults;
+  }
 
 
   const isHighlightTool =


### PR DESCRIPTION
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

Guard `window.Core?.Tools?.ToolNames` access in `getToolStyles.js` to prevent a `TypeError: Cannot read properties of undefined (reading 'ToolNames')` crash when the PDF Core is not yet initialised (e.g. during Core startup failure due to an AMS licence issue).

# What has changed?

- `src/helpers/getToolStyles.js`: Changed `window.Core.Tools.ToolNames` to `window.Core?.Tools?.ToolNames` and added an early return when `ToolNames` is unavailable, falling back to `tool?.defaults`.

# Notes for your reviewer

This is a companion fix to PR #66 (setBasePath guard). Both errors occur in the same degraded-Core scenario. Without the guard, `ToolButton` crashes immediately after the viewer fails to initialise, producing an unhandled `TypeError`.

## Jira links

```jira_links

```