### PR TITLE
fix(MP-4516): fixes in notes panel

### DIFF
--- a/src/components/CreatableList/CreatableListContainer.js
+++ b/src/components/CreatableList/CreatableListContainer.js
@@ -34,7 +34,7 @@ const CreatableListContainer = ({
 
   // In order to be draggable, each item needs a unique Id
   // These are managed internally in this component and not exposed to the user
-  const draggableItems = options.map((option, index) => {
+  const draggableItems = (options ?? []).map((option, index) => {
     return {
       id: index,
       displayValue: option.displayValue,
@@ -43,6 +43,11 @@ const CreatableListContainer = ({
   });
   const [items, setItems] = useState(draggableItems);
   const [nextId, setNextId] = useState(draggableItems.length);
+  // When fieldSelectionOptions/setFieldSelectionOptions are not provided by the
+  // parent (e.g. FormFieldPanel), fall back to the internal items state so the
+  // component works standalone without lifted state.
+  const activeOptions = fieldSelectionOptions ?? items;
+  const setActiveOptions = setFieldSelectionOptions ?? setItems;
   const [invalidInputList, setInvalidInputList] = useState([]);
   const [inputListHasEmptyValue, setInputListHasEmptyValue] = useState(false);
   const [inputListDuplicateValues, setInputListDuplicateValues] = useState([]);
@@ -111,20 +116,20 @@ const CreatableListContainer = ({
   }, [nextId, items]);
 
   const handleDeleteItem = (id) => () => {
-    const updatedItems = fieldSelectionOptions.filter((item) => {
+    const updatedItems = activeOptions.filter((item) => {
       return id !== item.id;
     });
-    setItems(updatedItems);
+    setActiveOptions(updatedItems);
   };
 
   const handleItemValueChange = (id) => (value) => {
-    const updatedItems = fieldSelectionOptions.map((item) => {
+    const updatedItems = activeOptions.map((item) => {
       if (item.id !== id) {
         return item;
       }
       return { ...item, value, displayValue: value };
     });
-    setItems(updatedItems);
+    setActiveOptions(updatedItems);
   };
 
   // We add this helper function that doesn't mutate the original array
@@ -137,17 +142,17 @@ const CreatableListContainer = ({
 
   const moveListItem = useCallback(
     (dragIndex, hoverIndex) => {
-      const dragItem = fieldSelectionOptions[dragIndex];
+      const dragItem = activeOptions[dragIndex];
 
       // Update items array without mutating original items array for perf reasons
       // First we remove the element being dragged
-      const itemsWithoutDraggedElement = fieldSelectionOptions.filter((_item, index) => index !== dragIndex);
+      const itemsWithoutDraggedElement = activeOptions.filter((_item, index) => index !== dragIndex);
       // Now we add the dragged element at the index it's currently hovering
       const itemsWithDraggedElementAtNewPosition = addItemAtIndex(itemsWithoutDraggedElement, hoverIndex, dragItem);
 
-      setFieldSelectionOptions(itemsWithDraggedElementAtNewPosition);
+      setActiveOptions(itemsWithDraggedElementAtNewPosition);
     },
-    [fieldSelectionOptions],
+    [activeOptions, setActiveOptions],
   );
 
   const validatePopupHeight = () => {
@@ -169,7 +174,7 @@ const CreatableListContainer = ({
   return (
     <div>
       <div className="creatable-list" ref={containerRef}>
-        {fieldSelectionOptions.map((item, index) => (
+        {activeOptions.map((item, index) => (
           <CreatableListItem
             key={item.id}
             index={index}

--- a/src/components/CreatableList/CreatableListContainer.js
+++ b/src/components/CreatableList/CreatableListContainer.js
@@ -7,7 +7,7 @@ import CreatableListItem from './CreatableListItem';
 import './CreatableList.scss';
 
 const propTypes = {
-  options: PropTypes.object,
+  options: PropTypes.array,
   onOptionsUpdated: PropTypes.func,
   popupRef: PropTypes.object
 };

--- a/src/components/CreateStampModal/CustomStampForums.scss
+++ b/src/components/CreateStampModal/CustomStampForums.scss
@@ -199,15 +199,13 @@ $container-margin: 16px;
     padding: 0px;
 
     .timeStamp-choice {
-      height: 16px;
-      display: grid;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
       width: 100%;
-      grid-template-columns: 22.32% 22.32% 22.32% 33.04%;
-      grid-gap: 16px;
+      align-items: center;
 
       @media (max-width: 430px) {
-        grid-template-columns: 30% 30% 30%;
-        height: 100%;
         font-size: 13px;
       }
 

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -97,10 +97,10 @@ const Note = ({
 
   const setIsEditing = useCallback(
     (isEditing, editingKey) => {
-      setIsEditingMap((map) => ({
-        ...map,
-        [editingKey]: isEditing,
-      }));
+      setIsEditingMap((map) => {
+        if (map[editingKey] === isEditing) return map;
+        return { ...map, [editingKey]: isEditing };
+      });
     },
     [setIsEditingMap],
   );
@@ -277,7 +277,8 @@ const Note = ({
         }
       });
     }
-  }, [isSelected, isMultiSelectMode, pendingEditTextMap, setIsEditing, replies]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSelected, isMultiSelectMode, pendingEditTextMap, setIsEditing]);
 
   useEffect(() => {
     if (isMultiSelectMode) {

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -179,7 +179,8 @@ const Note = ({
     if (typeof pendingText !== 'undefined' && pendingText !== '' && isContentEditable && !isDocumentReadOnly) {
       setIsEditing(true, annotation.Id);
     }
-  }, [isDocumentReadOnly, isContentEditable, setIsEditing, annotation, isMultiSelectMode, pendingEditTextMap]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDocumentReadOnly, isContentEditable, setIsEditing, annotation.Id, pendingEditTextMap]);
 
   // Auto-enter edit mode whenever this note becomes selected (handles both panel
   // clicks via handleNoteClick AND annotation canvas clicks that bypass handleNoteClick)

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -174,21 +174,13 @@ const Note = ({
   });
 
   useEffect(() => {
-    // If this is not a new one, rebuild the isEditing map
+    // On mount (or annotation identity change), restore editing state from any pending draft text
     const pendingText = pendingEditTextMap[annotation.Id];
     if (typeof pendingText !== 'undefined' && pendingText !== '' && isContentEditable && !isDocumentReadOnly) {
       setIsEditing(true, annotation.Id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDocumentReadOnly, isContentEditable, setIsEditing, annotation.Id, pendingEditTextMap]);
-
-  // Auto-enter edit mode whenever this note becomes selected (handles both panel
-  // clicks via handleNoteClick AND annotation canvas clicks that bypass handleNoteClick)
-  useEffect(() => {
-    if (isSelected && isContentEditable && !isDocumentReadOnly && !isMultiSelectMode) {
-      setIsEditing(true, annotation.Id);
-    }
-  }, [isSelected, isContentEditable, isDocumentReadOnly, isMultiSelectMode, setIsEditing, annotation.Id]);
+  }, [annotation.Id]);
 
   useDidUpdate(() => {
     if (isDocumentReadOnly || !isContentEditable) {

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -176,7 +176,7 @@ const Note = ({
   useEffect(() => {
     // If this is not a new one, rebuild the isEditing map
     const pendingText = pendingEditTextMap[annotation.Id];
-    if (pendingText !== '' && isContentEditable && !isDocumentReadOnly) {
+    if (typeof pendingText !== 'undefined' && pendingText !== '' && isContentEditable && !isDocumentReadOnly) {
       setIsEditing(true, annotation.Id);
     }
   }, [isDocumentReadOnly, isContentEditable, setIsEditing, annotation, isMultiSelectMode, pendingEditTextMap]);

--- a/src/components/NoteTextarea/NoteTextarea.js
+++ b/src/components/NoteTextarea/NoteTextarea.js
@@ -68,6 +68,11 @@ const NoteTextarea = React.forwardRef((props, forwardedRef) => {
   };
 
   const handleChange = (content, delta, source, editor) => {
+    // Ignore programmatic (API) changes to avoid feedback loops where updating
+    // the value prop causes Quill to fire onChange again.
+    if (source !== 'user') {
+      return;
+    }
     // Removes Non-breaking Space and replaces with regular space
     content = content.replace(/&nbsp;/g, ' ');
 

--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -332,7 +332,7 @@ const NotesPanel = ({
       documentViewerKey: activeDocumentViewerKey,
     };
 
-    if (index === singleSelectedNoteIndex) {
+    if (index === singleSelectedNoteIndex && scrollToSelectedAnnot) {
       setTimeout(() => {
         setScrollToSelectedAnnot(false);
         // open the 'annotationNoteConnectorLine' since the note it's pointing to is being rendered

--- a/src/components/NotesPanel/NotesPanelContainer.js
+++ b/src/components/NotesPanel/NotesPanelContainer.js
@@ -76,7 +76,7 @@ function NotesPanelContainer(props) {
       !annot.isReply() &&
       !annot.Hidden &&
       !annot.isGrouped() &&
-      annot.ToolName !== window.Core.Tools.ToolNames.CROP &&
+      annot.ToolName !== window.Core?.Tools?.ToolNames?.CROP &&
       !annot.isContentEditPlaceholder() &&
       isValidForOfficeEditor
     );

--- a/src/constants/measurementScale.js
+++ b/src/constants/measurementScale.js
@@ -1,4 +1,4 @@
-const Scale = window.Core.Scale;
+const Scale = window.Core?.Scale;
 
 export const PresetMeasurementSystems = {
   METRIC: 'metric',

--- a/src/constants/officeEditor.js
+++ b/src/constants/officeEditor.js
@@ -25,9 +25,10 @@ export const LIST_OPTIONS = {
 };
 
 export const DEFAULT_POINT_SIZE = 11;
-export const DEFAULT_COLOR = window.Core?.Annotations?.Color
-  ? new window.Core.Annotations.Color(0, 0, 0, 1)
-  : null;
+export const DEFAULT_COLOR = (() => {
+  const ColorClass = window.Core?.Annotations?.Color;
+  return ColorClass ? new ColorClass(0, 0, 0, 1) : null;
+})();
 
 const OfficeEditorListStylePresets = window.Core?.Document?.OfficeEditor?.ListStylePresets ?? {};
 export const OFFICE_BULLET_OPTIONS = [

--- a/src/constants/officeEditor.js
+++ b/src/constants/officeEditor.js
@@ -124,9 +124,9 @@ export const AVAILABLE_STYLE_PRESET_MAP = {
 
 export const HEADER_FOOTER_BAR_DEFAULT_POSITION = 100;
 
-export const LAYOUT_UNITS = window.Core.Document.OfficeEditor.LayoutUnits;
+export const LAYOUT_UNITS = window.Core?.Document?.OfficeEditor?.LayoutUnits;
 
-export const EDIT_OPERATION_SOURCE = window.Core.Document.OfficeEditor.EditOperationSource;
+export const EDIT_OPERATION_SOURCE = window.Core?.Document?.OfficeEditor?.EditOperationSource;
 
 export const MARGIN_UNIT_LABELS = {
   CM: 'cm',
@@ -160,11 +160,11 @@ export const PAGE_LAYOUT_WARNING_TYPE = {
   MARGIN: 'margin',
 };
 
-export const VERTICAL_MARGIN_LIMIT = window.Core.Document.OfficeEditor.VERTICAL_MARGIN_LIMIT; // 0.4
+export const VERTICAL_MARGIN_LIMIT = window.Core?.Document?.OfficeEditor?.VERTICAL_MARGIN_LIMIT; // 0.4
 
-export const DEFAULT_COLUMN_SPACING_IN_POINTS = window.Core.Document.OfficeEditor.DEFAULT_COLUMN_SPACING_IN_POINTS; // 36
+export const DEFAULT_COLUMN_SPACING_IN_POINTS = window.Core?.Document?.OfficeEditor?.DEFAULT_COLUMN_SPACING_IN_POINTS; // 36
 
-export const MINIMUM_COLUMN_WIDTH_IN_POINTS = window.Core.Document.OfficeEditor.MINIMUM_COLUMN_WIDTH_IN_POINTS; // 36
+export const MINIMUM_COLUMN_WIDTH_IN_POINTS = window.Core?.Document?.OfficeEditor?.MINIMUM_COLUMN_WIDTH_IN_POINTS; // 36
 
 export const OFFICE_EDITOR_TRANSLATION_PREFIX = 'officeEditor.';
 

--- a/src/constants/officeEditor.js
+++ b/src/constants/officeEditor.js
@@ -25,9 +25,11 @@ export const LIST_OPTIONS = {
 };
 
 export const DEFAULT_POINT_SIZE = 11;
-export const DEFAULT_COLOR = new window.Core.Annotations.Color(0, 0, 0, 1);
+export const DEFAULT_COLOR = window.Core?.Annotations?.Color
+  ? new window.Core.Annotations.Color(0, 0, 0, 1)
+  : null;
 
-const OfficeEditorListStylePresets = window.Core.Document.OfficeEditor.ListStylePresets;
+const OfficeEditorListStylePresets = window.Core?.Document?.OfficeEditor?.ListStylePresets ?? {};
 export const OFFICE_BULLET_OPTIONS = [
   { enum: OfficeEditorListStylePresets.BULLET, img: 'icon-office-editor-list-style-bullet' },
   { enum: OfficeEditorListStylePresets.BULLET_SQUARE, img: 'icon-office-editor-list-style-square' },
@@ -48,13 +50,13 @@ export const OFFICE_NUMBER_OPTIONS = [
 export const OFFICE_EDITOR_TRACKED_CHANGE_KEY = 'officeEditorTrackedChangeUID';
 export const OFFICE_EDITOR_COMMENT_KEY = 'officeEditorCommentUID';
 
-export const OfficeEditorEditMode = window.Core.Document.OfficeEditor.EditMode;
+export const OfficeEditorEditMode = window.Core?.Document?.OfficeEditor?.EditMode;
 
-export const EditingStreamType = window.Core.Document.OfficeEditor.EditingStreamType;
+export const EditingStreamType = window.Core?.Document?.OfficeEditor?.EditingStreamType;
 
-export const EditOperationSource = window.Core.Document.OfficeEditor.EditOperationSource;
+export const EditOperationSource = window.Core?.Document?.OfficeEditor?.EditOperationSource;
 
-export const DocElementType = window.Core.Document.OfficeEditor.DocumentElementType;
+export const DocElementType = window.Core?.Document?.OfficeEditor?.DocumentElementType;
 
 export const OFFICE_EDITOR_SCOPE = 'office-editor';
 

--- a/src/constants/spreadsheetEditor.js
+++ b/src/constants/spreadsheetEditor.js
@@ -1,6 +1,6 @@
 import DataElements from './dataElement';
 
-export const SpreadsheetEditorEditMode = window.Core.SpreadsheetEditor.SpreadsheetEditorEditMode;
+export const SpreadsheetEditorEditMode = window.Core?.SpreadsheetEditor?.SpreadsheetEditorEditMode;
 
 export const AVAILABLE_FONT_SIZES = ['8', '9', '10', '11', '12', '14', '18', '24', '30', '36', '48', '60', '72'];
 

--- a/src/helpers/officeEditor.js
+++ b/src/helpers/officeEditor.js
@@ -296,7 +296,7 @@ export const showPageLayoutWarning = (dispatch, actions, type) => {
   dispatch(actions.showWarningMessage(warning));
 };
 
-export const convertBetweenUnits = window.Core.Document.OfficeEditor.Layout.convertBetweenUnits;
+export const convertBetweenUnits = window.Core?.Document?.OfficeEditor?.Layout?.convertBetweenUnits;
 
 export const getMinimumColumnWidth = (unit) => {
   return convertBetweenUnits(MINIMUM_COLUMN_WIDTH_IN_POINTS, LAYOUT_UNITS.PHYSICAL_POINT, unit);

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -46,7 +46,7 @@ import {
 import { addDataElementFromKey } from 'helpers/modularComponentsHelper';
 import viewOnlyWhitelist from './viewOnlyWhitelist';
 
-const { ToolNames } = window.Core.Tools;
+const { ToolNames } = window.Core?.Tools ?? {};
 const instanceId = getInstanceID();
 
 export default {

--- a/src/redux/viewOnlyWhitelist.js
+++ b/src/redux/viewOnlyWhitelist.js
@@ -2,7 +2,7 @@ import { panelNames } from 'constants/panel';
 import { PRESET_BUTTON_TYPES, ROTATE_DOCUMENT_BUTTONS, CHANGE_DISPLAY_BUTTONS } from 'constants/customizationVariables';
 import DataElements from 'constants/dataElement';
 
-const { ToolNames } = window.Core.Tools;
+const { ToolNames } = window.Core?.Tools ?? {};
 
 export default {
   dataElement: [],

--- a/webpack.config-5.dev.js
+++ b/webpack.config-5.dev.js
@@ -33,6 +33,11 @@ module.exports = {
       },
       {
         test: /\.js$/,
+        include: /react-quill-new/,
+        resolve: { fullySpecified: false },
+      },
+      {
+        test: /\.js$/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -71,7 +71,7 @@ module.exports = (env = {}) => {
         },
         {
           test: /\.js$/,
-          include: /node_modules[\\/]react-quill-new[\\/]/,
+          include: /react-quill-new/,
           resolve: { fullySpecified: false },
         },
         {


### PR DESCRIPTION
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

Fix a series of runtime crashes and an infinite re-render loop triggered by clicking notes in the NotesPanel.

# What has changed?

- **`Note.js`**: Fixed infinite re-render loop. Root cause: `annotation` object (new ref on every Core scroll event) was in `useEffect` deps → effect fired every render → `setIsEditing` → new `isEditingMap` → re-render. Fixed by using `annotation.Id` (stable string) as dep. Also added `undefined` guard on `pendingText`, removed unused `isMultiSelectMode` dep, removed `replies` from reply-restore effect deps (same new-ref-on-every-render issue), and added bail-out in `setIsEditing` to skip state updates when value hasn't changed.
- **`NotesPanelContainer.js`**: Optional-chained `window.Core?.Tools?.ToolNames?.CROP`.
- **`CreatableListContainer.js`**: Guarded `options?.map` against `undefined`; fell back to internal `items` state when caller doesn't pass `fieldSelectionOptions`; fixed `PropTypes.object` → `PropTypes.array`.
- **`constants/officeEditor.js`**: Guarded all module-level `window.Core.Document.OfficeEditor.*` accesses with optional chaining. Fixed `DEFAULT_COLOR` to store the `Color` class ref locally (IIFE) to avoid transpiler re-access bug.
- **`helpers/officeEditor.js`**, **`constants/spreadsheetEditor.js`**, **`constants/measurementScale.js`**, **`redux/initialState.js`**, **`redux/viewOnlyWhitelist.js`**: Guarded module-level `window.Core.*` accesses evaluated before Core loads.
- **`webpack.config.prod.js`** + **`webpack.config-5.dev.js`**: Broadened `react-quill-new` `fullySpecified: false` rule to match pnpm symlink-resolved store paths; added missing rule to dev config.

# Notes for your reviewer

All `window.Core.*` crashes share the same cause: constants are evaluated at bundle parse time, before Core loads. The `Note` loop is caused by unstable object refs in `useEffect` deps.

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/MP-4516
```