### PR TITLE
fix: fixed autosave stuck in editing mode

### DIFF
--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -665,6 +665,8 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
   const setContents = async (e) => {
     e.preventDefault();
 
+    setSavedState(AnnotationSavedState.SAVING);
+
     const editor = textareaRef.current.getEditor();
     textAreaValue = mentionsManager.getFormattedTextFromDeltas(editor.getContents());
     if (typeof textAreaValue === 'string' && textAreaValue.replace(/<br\s*\/?>(\s*)?/gi, '').trim() === '') {
@@ -682,58 +684,71 @@ const ContentArea = ({ annotation, noteIndex, setIsEditing, textAreaValue, onTex
       annotation.disableSkipAutoLink();
     }
 
-    if (isOfficeEditorCommentAnnotation) {
-      const didUpdate = await updateOfficeEditorCommentMessage({
-        annotation,
-        text: textAreaValue,
-        core,
-      });
-      if (!didUpdate) {
-        return;
-      }
-    }
-
-    if (isMentionEnabled && !isOfficeEditorCommentAnnotation) {
-      const { plainTextValue, ids } = mentionsManager.extractMentionDataFromStr(textAreaValue);
-
-      // If modified, double check for ids
-      const annotMentionData = mentionsManager.extractMentionDataFromAnnot(annotation);
-      annotMentionData.mentions.forEach((mention) => {
-        if (plainTextValue.includes(mention.value)) {
-          ids.push(mention.id);
+    try {
+      if (isOfficeEditorCommentAnnotation) {
+        const didUpdate = await updateOfficeEditorCommentMessage({
+          annotation,
+          text: textAreaValue,
+          core,
+        });
+        if (!didUpdate) {
+          setSavedState(AnnotationSavedState.ERROR);
+          return;
         }
-      });
-
-      annotation.setCustomData(
-        'trn-mention',
-        JSON.stringify({
-          contents: textAreaValue,
-          ids,
-        }),
-      );
-      annotation.setContents(plainTextValue ?? '');
-    } else {
-      annotation.setContents(textAreaValue ?? '');
-    }
-
-    await setAnnotationAttachments(annotation, pendingAttachmentMap[annotation.Id]);
-
-    const source = annotation instanceof window.Core.Annotations.FreeTextAnnotation ? 'textChanged' : 'noteChanged';
-    core
-      .getAnnotationManager(activeDocumentViewerKey)
-      .trigger('annotationChanged', [[annotation], 'modify', { source }]);
-
-    if (annotation instanceof window.Core.Annotations.FreeTextAnnotation) {
-      core.drawAnnotationsFromList([annotation]);
-    }
-
-    hasUnsavedEditsRef.current = false;
-
-    if (e && e.type === 'blur') {
-      if (textAreaValue !== '') {
-        onTextAreaValueChange(undefined, annotation.Id);
       }
-      clearAttachments(annotation.Id);
+
+      if (isMentionEnabled && !isOfficeEditorCommentAnnotation) {
+        const { plainTextValue, ids } = mentionsManager.extractMentionDataFromStr(textAreaValue);
+
+        // If modified, double check for ids
+        const annotMentionData = mentionsManager.extractMentionDataFromAnnot(annotation);
+        annotMentionData.mentions.forEach((mention) => {
+          if (plainTextValue.includes(mention.value)) {
+            ids.push(mention.id);
+          }
+        });
+
+        annotation.setCustomData(
+          'trn-mention',
+          JSON.stringify({
+            contents: textAreaValue,
+            ids,
+          }),
+        );
+        annotation.setContents(plainTextValue ?? '');
+      } else {
+        annotation.setContents(textAreaValue ?? '');
+      }
+
+      await setAnnotationAttachments(annotation, pendingAttachmentMap[annotation.Id]);
+
+      const source = annotation instanceof window.Core.Annotations.FreeTextAnnotation ? 'textChanged' : 'noteChanged';
+      core
+        .getAnnotationManager(activeDocumentViewerKey)
+        .trigger('annotationChanged', [[annotation], 'modify', { source }]);
+
+      if (annotation instanceof window.Core.Annotations.FreeTextAnnotation) {
+        core.drawAnnotationsFromList([annotation]);
+      }
+
+      hasUnsavedEditsRef.current = false;
+      setSavedState(AnnotationSavedState.SAVED);
+
+      try {
+        localStorage.removeItem(`annotation_draft_${annotation.Id}`);
+      } catch (storageError) {
+        console.error('Failed to clear localStorage draft:', storageError);
+      }
+
+      if (e && e.type === 'blur') {
+        if (textAreaValue !== '') {
+          onTextAreaValueChange(undefined, annotation.Id);
+        }
+        clearAttachments(annotation.Id);
+      }
+    } catch (err) {
+      console.error('Failed to save annotation:', err);
+      setSavedState(AnnotationSavedState.ERROR);
     }
   };
 

--- a/src/components/NoteHeader/NoteHeader.js
+++ b/src/components/NoteHeader/NoteHeader.js
@@ -213,7 +213,7 @@ function NoteHeader(props) {
     core.getOfficeEditor().rejectTrackedChange(trackedChangeId);
   };
 
-  const showNotePopup = !isEditing && isSelected && !isMultiSelectMode && !isGroupMember && !isTrackedChange && !isOfficeEditorViewOnly;
+  const showNotePopup = isSelected && !isMultiSelectMode && !isGroupMember && !isTrackedChange && !isOfficeEditorViewOnly;
   const flyoutId = flyoutIdSuffix ? `${annotation.Id}-${flyoutIdSuffix}` : annotation.Id;
 
   const pageNumber = annotation.getPageNumber();

--- a/src/components/NoteTextarea/CommentTextarea/CommentTextarea.js
+++ b/src/components/NoteTextarea/CommentTextarea/CommentTextarea.js
@@ -112,7 +112,6 @@ const CommentTextarea = React.forwardRef(
       e.stopPropagation();
     };
 
-    value = transformTextForQuill(value);
     const baseModule = { blurInput: {} };
 
     // onBlur and onFocus have to be outside in the div because of quill bug
@@ -130,9 +129,9 @@ const CommentTextarea = React.forwardRef(
           }}
           modules={userData && userData.length > 0 ? { ...baseModule, ...mentionModule } : baseModule }
           theme="snow"
-          value={value}
+          defaultValue={transformTextForQuill(value)}
           placeholder={`${isReply ? t('action.reply') : t('action.comment')}...`}
-          onChange={onChange}
+          onChange={onchange}
           onKeyDown={onKeyDown}
           formats={formats}
         />


### PR DESCRIPTION
<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
* Annotation autosave stuck in editing mode
* Annotation options not displayed
# What has changed?

# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/MP-4514
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->