### PR TITLE
fix: upgrade Node.js to v22 in CI for pnpm 11 compatibility

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://npm.pkg.github.com/
           always-auth: true
           scope: '@uniwise'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Apryse Software Inc.",
   "version": "11.12.0",
   "description": "WebViewer UI built in React",
+  "packageManager": "pnpm@11.1.0",
   "files": [
     "./build"
   ],


### PR DESCRIPTION
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?

pnpm@11.1.0 requires Node.js v22.13 or higher. The CI workflow was running Node.js v20, causing `pnpm install --frozen-lockfile` to fail with `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite`.

# What has changed?

Bumped `node-version` from `20.x` to `22.x` in `.github/workflows/deploy.yaml`.

# Notes for your reviewer

No logic changes — only the Node.js version used in CI.

## Jira links

```jira_links

```