### PR TITLE
fixed(MP-4551): added so newly created annotation automatically enter…

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -270,6 +270,15 @@ const Note = ({
         }
       });
     }
+
+    // When a new annotation (with no content) is selected, automatically enter edit mode
+    if (isSelected && isContentEditable && !isDocumentReadOnly && !isMultiSelectMode) {
+      const hasContent = !!annotation.getContents();
+      const hasPendingText = typeof pendingEditTextMap[annotation.Id] !== 'undefined';
+      if (!hasContent && !hasPendingText) {
+        setIsEditing(true, annotation.Id);
+      }
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSelected, isMultiSelectMode, pendingEditTextMap, setIsEditing]);
 


### PR DESCRIPTION
… edit mode

<!-- To help speed up the review process, please fill out the following sections -->
- [ ] Documented PDFtron customisation in [Wiseflow_PDFtron.docs](https://uniwise1.sharepoint.com/:w:/r/sites/uniwise/_layouts/15/doc.aspx?sourcedoc=%7B31449df0-0514-41ef-adc2-aaedfb35d8e1%7D&action=edit&cid=76807666-6e9a-4a89-a296-9b424fbfece6)

# What is the purpose of this pull request?
Adding annotation exits edit mode immediately — requires separate click to edit

# What has changed?

# Notes for your reviewer

## Jira links

```jira_links
https://uniwise.atlassian.net/browse/MP-4551
```


[Read more about Pull Request best practices here](https://github.com/UNIwise/developer-conventions/blob/master/general/git.md)


<!-- Example:
"Based on user feedback, the animation should be more subtle"

"Changed the starting color to lessen the color change during animation
Changed the starting size to lessen the size change during animation
See attached gif"

"I also fixed a couple of syntax errors I found while working on this"
-->